### PR TITLE
feat: implement Clerk + Tidal OAuth authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Auto-generated from all feature plans. Last updated: 2025-12-27
 - N/A (no storage changes) (014-tidal-search-refinement)
 - TypeScript 5.3.3 / Node.js 20.x (backend), TypeScript 5.3.3 / React 18.2.0 (frontend) + Vercel AI SDK (`ai`, `@ai-sdk/anthropic`), Zod 3.x, axios 1.6+, Apollo Server 4.x, Apollo Client 3.x (015-playlist-suggestion)
 - PostgreSQL (via TypeORM - Message.content JSONB field for tool blocks), existing rate limiter for Tidal API (015-playlist-suggestion)
+- Clerk private metadata (Tidal tokens), existing PostgreSQL (no schema changes needed for auth) (016-clerk-tidal-auth)
 
 ## Project Structure
 
@@ -224,9 +225,9 @@ Access at http://localhost:3000 when Langfuse is running.
 | `CHAT_MAX_TOKENS` | No | `4096` | Maximum tokens for chat responses |
 
 ## Recent Changes
+- 016-clerk-tidal-auth: Added TypeScript 5.3.3 / Node.js 20.x (backend), TypeScript 5.3.3 / React 18.2.0 (frontend)
 - 015-playlist-suggestion: Added TypeScript 5.3.3 / Node.js 20.x (backend), TypeScript 5.3.3 / React 18.2.0 (frontend) + Vercel AI SDK (`ai`, `@ai-sdk/anthropic`), Zod 3.x, axios 1.6+, Apollo Server 4.x, Apollo Client 3.x
 - 014-tidal-search-refinement: Added TypeScript 5.3.3 / Node.js 20.x (backend) + Vercel AI SDK (`ai`, `@ai-sdk/anthropic`), Zod 3.x
-- 013-agent-tool-optimization: Added TypeScript 5.3.3 / Node.js 20.x + @qdrant/js-client-rest (Qdrant client), Vercel AI SDK (agent), Zod (validation)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,10 @@
 TIDAL_CLIENT_ID=your_client_id_here
 TIDAL_CLIENT_SECRET=your_client_secret_here
 
+# Clerk Authentication
+CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+
 # Tidal API Configuration
 TIDAL_TOKEN_URL=https://auth.tidal.com/v1/oauth2/token
 TIDAL_API_BASE_URL=https://openapi.tidal.com

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,184 @@
+# AlgoJuke Backend
+
+GraphQL API server for AI-powered music discovery with Tidal integration.
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js 20.x or higher
+- Docker and Docker Compose (for PostgreSQL)
+- Clerk account with Google OAuth enabled
+- Tidal Developer account
+
+### Installation
+
+```bash
+cd backend
+npm install
+```
+
+### Environment Setup
+
+Copy the example environment file:
+
+```bash
+cp .env.example .env
+```
+
+Configure the following required variables:
+
+| Variable | Description |
+|----------|-------------|
+| `CLERK_PUBLISHABLE_KEY` | Clerk publishable key (pk_test_...) |
+| `CLERK_SECRET_KEY` | Clerk secret key (sk_test_...) |
+| `TIDAL_CLIENT_ID` | Tidal API client ID |
+| `TIDAL_CLIENT_SECRET` | Tidal API client secret |
+| `DATABASE_URL` | PostgreSQL connection string |
+
+### Running the Server
+
+1. **Start PostgreSQL**:
+
+   ```bash
+   docker compose up db -d
+   ```
+
+2. **Run database migrations**:
+
+   ```bash
+   npm run migration:run
+   ```
+
+3. **Start the development server**:
+
+   ```bash
+   npm run dev
+   ```
+
+   The GraphQL API will be available at http://localhost:4000/graphql
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run auth tests only
+npm test -- tests/contract/auth tests/integration/auth
+
+# Type checking
+npm run type-check
+```
+
+## Authentication
+
+The backend uses Clerk for authentication with a private beta allowlist.
+
+### Architecture
+
+1. **Clerk Middleware**: All requests pass through `clerkMiddleware()` which validates JWT tokens
+2. **Allowlist**: Only approved emails (defined in `src/config/allowlist.ts`) can access protected routes
+3. **Tidal Tokens**: Stored in Clerk private metadata (8KB limit)
+
+### Auth Endpoints
+
+| Endpoint | Method | Auth Required | Description |
+|----------|--------|---------------|-------------|
+| `/api/auth/status` | GET | No | Get current user's auth state |
+| `/api/auth/tidal/tokens` | GET | Yes | Get Tidal token status |
+| `/api/auth/tidal/tokens` | POST | Yes + Approved | Store Tidal OAuth tokens |
+| `/api/auth/tidal/refresh` | POST | Yes + Approved | Update Tidal tokens after SDK refresh |
+
+#### GET /api/auth/status
+
+Returns the current user's authentication state:
+
+```json
+{
+  "isAuthenticated": true,
+  "isApproved": true,
+  "hasTidalConnection": true,
+  "tidalTokenExpired": false,
+  "email": "user@example.com",
+  "userId": "user_xxx"
+}
+```
+
+- `tidalTokenExpired`: If true, the frontend should refresh tokens via Tidal SDK and sync to backend
+
+#### POST /api/auth/tidal/tokens
+
+Stores Tidal OAuth tokens. Validates that all required scopes are present:
+
+```json
+{
+  "accessToken": "...",
+  "refreshToken": "...",
+  "expiresAt": 1704067200000,
+  "scopes": ["user.read", "collection.read", "playlists.read", "playlists.write", "recommendations.read", "search.read"]
+}
+```
+
+Returns 400 if required scopes are missing.
+
+### Adding Approved Users
+
+Edit `src/config/allowlist.ts`:
+
+```typescript
+export const APPROVED_EMAILS = [
+  'anton.tcholakov@gmail.com',
+  'new.user@example.com', // Add new users here
+] as const;
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/config/allowlist.ts` | Approved email addresses |
+| `src/middleware/clerkAuth.ts` | Clerk middleware and auth guards |
+| `src/routes/auth.ts` | Auth API endpoints |
+| `src/services/tidalAuthService.ts` | Tidal token storage/retrieval |
+| `src/schemas/auth.ts` | Zod schemas for auth contracts |
+
+## Project Structure
+
+```
+backend/
+├── src/
+│   ├── config/
+│   │   └── allowlist.ts        # Beta allowlist
+│   ├── middleware/
+│   │   └── clerkAuth.ts        # Auth middleware
+│   ├── routes/
+│   │   └── auth.ts             # Auth endpoints
+│   ├── services/
+│   │   └── tidalAuthService.ts # Tidal token management
+│   ├── schemas/
+│   │   └── auth.ts             # Zod schemas
+│   └── server.ts               # Express server entry
+├── tests/
+│   ├── contract/auth/          # Contract tests
+│   └── integration/auth/       # Integration tests
+└── package.json
+```
+
+## Troubleshooting
+
+### "User not approved for beta access"
+
+The signed-in user's email is not in the allowlist. Add their email to `src/config/allowlist.ts`.
+
+### Clerk middleware not authenticating
+
+1. Verify `CLERK_SECRET_KEY` is set correctly in `.env`
+2. Check that `clerkMiddleware()` is applied before routes in `server.ts`
+3. Ensure the frontend is sending the Clerk session token
+
+### Tidal token storage failing
+
+1. Verify the user is approved (in allowlist)
+2. Check that token data matches the `TidalTokensInputSchema`
+3. Review Clerk private metadata limits (8KB max)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.2",
         "@apollo/server": "^4.10.0",
+        "@clerk/backend": "^2.29.0",
+        "@clerk/express": "^1.7.60",
         "@langfuse/otel": "^4.5.1",
         "@qdrant/js-client-rest": "^1.12.0",
         "ai": "^6.0.5",
@@ -425,6 +427,91 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.2.tgz",
       "integrity": "sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@clerk/backend": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.29.0.tgz",
+      "integrity": "sha512-cw4CK6ZHgeFROirlIOawelqRBxZAyH6v3GPSYZEEzYAL0WWUHx7cMXzoQcTMruH7w6UM7s3Ox+uUcINESWkQPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.41.1",
+        "@clerk/types": "^4.101.9",
+        "cookie": "1.0.2",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clerk/express": {
+      "version": "1.7.60",
+      "resolved": "https://registry.npmjs.org/@clerk/express/-/express-1.7.60.tgz",
+      "integrity": "sha512-yQ7mhiFcq9sSJXqFV8W2NS131HgEJ+AEibgkUoVXO78kneps6iPM7ofF+/o84k8gQS92Yd3KcB+8SQBGLMyY9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^2.29.0",
+        "@clerk/shared": "^3.41.1",
+        "@clerk/types": "^4.101.9",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "express": "^4.17.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.41.1.tgz",
+      "integrity": "sha512-BCbT7Xodk2rndA2nV/lW8X5LMNTvFP5UG2wNN9cYuAcTaI6hYZP18/z2zef2gG4xIrK7WAEjGVzHscikqNtzFQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.101.9",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.9.tgz",
+      "integrity": "sha512-RO00JqqmkIoI1o0XCtvudjaLpqEoe8PRDHlLS1r/aNZazUQCO0TT6nZOx1F3X+QJDjqYVY7YmYl3mtO2QVEk1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.41.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -3140,6 +3227,12 @@
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4364,6 +4457,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
     "node_modules/dataloader": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
@@ -4460,6 +4559,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -5021,6 +5129,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5416,6 +5530,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -6040,6 +6160,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -7148,6 +7277,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -7631,6 +7770,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7644,7 +7793,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -7750,6 +7898,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/temporal-polyfill": {
@@ -8214,6 +8375,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utils-merge": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.2",
     "@apollo/server": "^4.10.0",
+    "@clerk/backend": "^2.29.0",
+    "@clerk/express": "^1.7.60",
     "@langfuse/otel": "^4.5.1",
     "@qdrant/js-client-rest": "^1.12.0",
     "ai": "^6.0.5",

--- a/backend/src/config/allowlist.ts
+++ b/backend/src/config/allowlist.ts
@@ -1,0 +1,28 @@
+/**
+ * Allowlist configuration for approved beta users
+ *
+ * During private beta, only users with emails in this list
+ * can connect their Tidal account and access the application.
+ */
+
+/**
+ * List of approved Google email addresses for private beta access.
+ * Emails are stored in lowercase for case-insensitive comparison.
+ */
+export const APPROVED_EMAILS = [
+  'anton.tcholakov@gmail.com',
+] as const;
+
+export type ApprovedEmail = (typeof APPROVED_EMAILS)[number];
+
+/**
+ * Check if a user's email is on the allowlist
+ *
+ * @param email - User's email address (case-insensitive)
+ * @returns true if user is approved for beta access
+ */
+export function isApprovedUser(email: string): boolean {
+  return APPROVED_EMAILS.includes(
+    email.toLowerCase() as ApprovedEmail
+  );
+}

--- a/backend/src/middleware/clerkAuth.ts
+++ b/backend/src/middleware/clerkAuth.ts
@@ -1,0 +1,88 @@
+/**
+ * Clerk Authentication Middleware
+ *
+ * Provides middleware for protecting routes and checking user authorization.
+ */
+
+import { clerkMiddleware, getAuth, clerkClient } from '@clerk/express';
+import type { Request, Response, NextFunction } from 'express';
+import { isApprovedUser } from '../config/allowlist.js';
+
+/**
+ * Initialize Clerk middleware for Express
+ * This populates req.auth with the user's authentication state
+ */
+export { clerkMiddleware };
+
+/**
+ * Get Clerk client for backend operations
+ */
+export { clerkClient };
+
+/**
+ * Middleware that requires the user to be authenticated
+ * Returns 401 if not authenticated
+ */
+export function requireAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const auth = getAuth(req);
+
+  if (!auth?.userId) {
+    res.status(401).json({
+      error: 'unauthorized',
+      message: 'Authentication required',
+    });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Middleware that requires the user to be on the approved allowlist
+ * Returns 401 if not authenticated, 403 if not approved
+ */
+export async function requireApproved(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const auth = getAuth(req);
+
+  if (!auth?.userId) {
+    res.status(401).json({
+      error: 'unauthorized',
+      message: 'Authentication required',
+    });
+    return;
+  }
+
+  try {
+    const user = await clerkClient.users.getUser(auth.userId);
+    const email = user.primaryEmailAddress?.emailAddress;
+
+    if (!email || !isApprovedUser(email)) {
+      res.status(403).json({
+        error: 'forbidden',
+        message: 'User not approved for beta access',
+      });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    console.error('Error checking user approval:', error);
+    res.status(500).json({
+      error: 'internal_error',
+      message: 'Failed to verify user status',
+    });
+  }
+}
+
+/**
+ * Helper to get the current user's auth object
+ */
+export { getAuth };

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,244 @@
+/**
+ * Auth API Routes
+ *
+ * Endpoints for authentication status and Tidal token management.
+ */
+
+import { Router, Request, Response } from 'express';
+import { getAuth, clerkClient } from '../middleware/clerkAuth.js';
+import { requireAuth, requireApproved } from '../middleware/clerkAuth.js';
+import { isApprovedUser } from '../config/allowlist.js';
+import {
+  getTidalTokens,
+  storeTidalTokens,
+  hasTidalConnection,
+  isTokenExpired,
+  refreshTidalTokens,
+} from '../services/tidalAuthService.js';
+import {
+  TidalTokensInputSchema,
+  hasRequiredScopes,
+  REQUIRED_TIDAL_SCOPES,
+  type AuthStatus,
+  type TidalTokensResponse,
+  type TidalTokenStatus,
+} from '../schemas/auth.js';
+
+/**
+ * Create auth routes
+ */
+export function createAuthRoutes(): Router {
+  const router = Router();
+
+  /**
+   * GET /api/auth/status
+   * Get current user's authentication status
+   */
+  router.get('/status', async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+
+    // Not authenticated
+    if (!auth?.userId) {
+      const response: AuthStatus = {
+        isAuthenticated: false,
+        isApproved: false,
+        hasTidalConnection: false,
+      };
+      res.json(response);
+      return;
+    }
+
+    try {
+      const user = await clerkClient.users.getUser(auth.userId);
+      const email = user.primaryEmailAddress?.emailAddress;
+      const approved = email ? isApprovedUser(email) : false;
+      const hasTidal = await hasTidalConnection(auth.userId);
+
+      // Check if token is expired (for frontend to trigger refresh)
+      let tidalTokenExpired: boolean | undefined;
+      if (hasTidal) {
+        const expired = await isTokenExpired(auth.userId);
+        tidalTokenExpired = expired ?? undefined;
+      }
+
+      const response: AuthStatus & { tidalTokenExpired?: boolean } = {
+        isAuthenticated: true,
+        isApproved: approved,
+        hasTidalConnection: hasTidal,
+        tidalTokenExpired,
+        email: email,
+        userId: auth.userId,
+      };
+      res.json(response);
+    } catch (error) {
+      console.error('Error fetching auth status:', error);
+      res.status(500).json({
+        error: 'internal_error',
+        message: 'Failed to fetch auth status',
+      });
+    }
+  });
+
+  /**
+   * POST /api/auth/tidal/tokens
+   * Store Tidal OAuth tokens (requires approved user)
+   */
+  router.post(
+    '/tidal/tokens',
+    requireAuth,
+    requireApproved,
+    async (req: Request, res: Response) => {
+      const auth = getAuth(req);
+
+      // Validate request body
+      const parsed = TidalTokensInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'validation_error',
+          message: 'Invalid token data',
+          details: parsed.error.issues,
+        });
+        return;
+      }
+
+      // Validate that all required scopes are present (FR-006)
+      if (!hasRequiredScopes(parsed.data.scopes)) {
+        res.status(400).json({
+          error: 'insufficient_scopes',
+          message: 'Missing required Tidal scopes',
+          requiredScopes: REQUIRED_TIDAL_SCOPES,
+          providedScopes: parsed.data.scopes,
+        });
+        return;
+      }
+
+      try {
+        const connectedAt = await storeTidalTokens(auth!.userId!, parsed.data);
+
+        const response: TidalTokensResponse = {
+          success: true,
+          connectedAt,
+        };
+        res.json(response);
+      } catch (error) {
+        console.error('Error storing Tidal tokens:', error);
+        res.status(500).json({
+          error: 'internal_error',
+          message: 'Failed to store Tidal tokens',
+        });
+      }
+    }
+  );
+
+  /**
+   * GET /api/auth/tidal/tokens
+   * Get Tidal token status (does not return actual tokens)
+   */
+  router.get('/tidal/tokens', requireAuth, async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+
+    try {
+      const tokens = await getTidalTokens(auth!.userId!);
+
+      if (!tokens) {
+        const response: TidalTokenStatus = {
+          hasTokens: false,
+        };
+        res.json(response);
+        return;
+      }
+
+      const expired = await isTokenExpired(auth!.userId!);
+
+      const response: TidalTokenStatus = {
+        hasTokens: true,
+        expiresAt: tokens.expiresAt,
+        isExpired: expired ?? undefined,
+        scopes: tokens.scopes,
+      };
+      res.json(response);
+    } catch (error) {
+      console.error('Error fetching Tidal token status:', error);
+      res.status(500).json({
+        error: 'internal_error',
+        message: 'Failed to fetch Tidal token status',
+      });
+    }
+  });
+
+  /**
+   * POST /api/auth/tidal/refresh
+   * Refresh Tidal access token
+   *
+   * Can be called two ways:
+   * 1. With body: Updates stored tokens with new values from SDK refresh
+   * 2. Without body: Returns current token status (for checking expiration)
+   */
+  router.post(
+    '/tidal/refresh',
+    requireAuth,
+    requireApproved,
+    async (req: Request, res: Response) => {
+      const auth = getAuth(req);
+
+      try {
+        // Check if tokens are provided (frontend refreshed via SDK)
+        const hasBody = req.body && Object.keys(req.body).length > 0;
+
+        if (hasBody) {
+          // Validate and update tokens
+          const parsed = TidalTokensInputSchema.safeParse(req.body);
+          if (!parsed.success) {
+            res.status(400).json({
+              error: 'validation_error',
+              message: 'Invalid token data',
+              details: parsed.error.issues,
+            });
+            return;
+          }
+
+          // Use refreshTidalTokens which includes structured logging
+          const result = await refreshTidalTokens(auth!.userId!, parsed.data);
+
+          const response: TidalTokenStatus = {
+            hasTokens: true,
+            expiresAt: result.expiresAt,
+            isExpired: false,
+            scopes: parsed.data.scopes,
+          };
+          res.json(response);
+          return;
+        }
+
+        // No body - just return current token status
+        const tokens = await getTidalTokens(auth!.userId!);
+
+        if (!tokens) {
+          res.status(422).json({
+            error: 'no_connection',
+            message: 'No Tidal connection found',
+          });
+          return;
+        }
+
+        const expired = await isTokenExpired(auth!.userId!);
+
+        const response: TidalTokenStatus = {
+          hasTokens: true,
+          expiresAt: tokens.expiresAt,
+          isExpired: expired ?? undefined,
+          scopes: tokens.scopes,
+        };
+        res.json(response);
+      } catch (error) {
+        console.error('Error refreshing Tidal tokens:', error);
+        res.status(500).json({
+          error: 'internal_error',
+          message: 'Failed to refresh Tidal tokens',
+        });
+      }
+    }
+  );
+
+  return router;
+}

--- a/backend/src/schemas/auth.ts
+++ b/backend/src/schemas/auth.ts
@@ -1,0 +1,125 @@
+/**
+ * Auth API Schemas
+ * Copied from specs/016-clerk-tidal-auth/contracts/schemas.ts
+ *
+ * These Zod schemas define the contract between frontend and backend
+ * for authentication and Tidal connection endpoints.
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Request Schemas
+// ============================================================================
+
+/**
+ * Schema for storing Tidal OAuth tokens
+ * POST /api/auth/tidal/tokens
+ */
+export const TidalTokensInputSchema = z.object({
+  accessToken: z.string().min(1, 'Access token is required'),
+  refreshToken: z.string().min(1, 'Refresh token is required'),
+  expiresAt: z.number().positive('Expiration must be a positive timestamp'),
+  scopes: z.array(z.string()).min(1, 'At least one scope is required'),
+});
+
+export type TidalTokensInput = z.infer<typeof TidalTokensInputSchema>;
+
+// ============================================================================
+// Response Schemas
+// ============================================================================
+
+/**
+ * Schema for auth status response
+ * GET /api/auth/status
+ */
+export const AuthStatusSchema = z.object({
+  isAuthenticated: z.boolean(),
+  isApproved: z.boolean(),
+  hasTidalConnection: z.boolean(),
+  /** True if Tidal access token is expired; frontend should trigger refresh */
+  tidalTokenExpired: z.boolean().optional(),
+  email: z.string().email().optional(),
+  userId: z.string().optional(),
+});
+
+export type AuthStatus = z.infer<typeof AuthStatusSchema>;
+
+/**
+ * Schema for Tidal tokens storage response
+ * POST /api/auth/tidal/tokens
+ */
+export const TidalTokensResponseSchema = z.object({
+  success: z.boolean(),
+  connectedAt: z.number().positive(),
+});
+
+export type TidalTokensResponse = z.infer<typeof TidalTokensResponseSchema>;
+
+/**
+ * Schema for Tidal token status response
+ * GET /api/auth/tidal/tokens
+ */
+export const TidalTokenStatusSchema = z.object({
+  hasTokens: z.boolean(),
+  expiresAt: z.number().optional(),
+  isExpired: z.boolean().optional(),
+  scopes: z.array(z.string()).optional(),
+});
+
+export type TidalTokenStatus = z.infer<typeof TidalTokenStatusSchema>;
+
+/**
+ * Schema for error responses
+ */
+export const ErrorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+});
+
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
+// ============================================================================
+// Internal Schemas (Backend Only)
+// ============================================================================
+
+/**
+ * Schema for Tidal tokens stored in Clerk private metadata
+ * This is the complete token object including connectedAt
+ */
+export const TidalTokensSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  expiresAt: z.number().positive(),
+  scopes: z.array(z.string()).min(1),
+  connectedAt: z.number().positive(),
+});
+
+export type TidalTokens = z.infer<typeof TidalTokensSchema>;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Required Tidal OAuth scopes
+ */
+export const REQUIRED_TIDAL_SCOPES = [
+  'collection.read',
+  'playlists.read',
+  'playlists.write',
+  'recommendations.read',
+  'search.read',
+  'user.read',
+] as const;
+
+export type TidalScope = (typeof REQUIRED_TIDAL_SCOPES)[number];
+
+/**
+ * Validate that all required scopes are present
+ */
+export function hasRequiredScopes(scopes: string[]): boolean {
+  return REQUIRED_TIDAL_SCOPES.every((required) =>
+    scopes.includes(required)
+  );
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,6 +24,8 @@ import { DiscoveryService } from './services/discoveryService.js';
 import { ChatService } from './services/chatService.js';
 import { createIsrcDataLoader } from './loaders/isrcDataLoader.js';
 import { createChatRoutes } from './routes/chatRoutes.js';
+import { createAuthRoutes } from './routes/auth.js';
+import { clerkMiddleware } from './middleware/clerkAuth.js';
 import { logger } from './utils/logger.js';
 import { initializeDatabase, AppDataSource } from './config/database.js';
 import { LibraryAlbum } from './entities/LibraryAlbum.js';
@@ -157,6 +159,12 @@ async function startServer() {
     // Apply middleware
     app.use(cors());
     app.use(express.json());
+
+    // Apply Clerk authentication middleware (populates req.auth)
+    app.use(clerkMiddleware());
+
+    // Mount auth routes (for Clerk + Tidal token management)
+    app.use('/api/auth', createAuthRoutes());
 
     // Mount chat REST routes (for SSE streaming) with tool support
     app.use('/api/chat', createChatRoutes({

--- a/backend/src/services/tidalAuthService.ts
+++ b/backend/src/services/tidalAuthService.ts
@@ -1,0 +1,203 @@
+/**
+ * Tidal Auth Service
+ *
+ * Manages Tidal OAuth tokens stored in Clerk private metadata.
+ */
+
+import { clerkClient } from '@clerk/express';
+import { TidalTokens, TidalTokensSchema, TidalTokensInput } from '../schemas/auth.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Get Tidal tokens for a user from Clerk private metadata
+ *
+ * @param userId - Clerk user ID
+ * @returns Tidal tokens if connected, null otherwise
+ */
+export async function getTidalTokens(userId: string): Promise<TidalTokens | null> {
+  try {
+    const user = await clerkClient.users.getUser(userId);
+    const tidalData = user.privateMetadata?.tidal;
+
+    if (!tidalData) {
+      return null;
+    }
+
+    // Validate the stored data matches our schema
+    const parsed = TidalTokensSchema.safeParse(tidalData);
+    if (!parsed.success) {
+      logger.warn('tidal_tokens_invalid', {
+        userId,
+        errors: parsed.error.issues,
+      });
+      return null;
+    }
+
+    return parsed.data;
+  } catch (error) {
+    logger.error('get_tidal_tokens_failed', {
+      userId,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+
+/**
+ * Store Tidal tokens for a user in Clerk private metadata
+ *
+ * @param userId - Clerk user ID
+ * @param tokens - Tidal OAuth tokens from frontend
+ * @returns Connection timestamp
+ */
+export async function storeTidalTokens(
+  userId: string,
+  tokens: TidalTokensInput
+): Promise<number> {
+  const startTime = Date.now();
+  const connectedAt = Date.now();
+
+  try {
+    const tidalTokens: TidalTokens = {
+      ...tokens,
+      connectedAt,
+    };
+
+    await clerkClient.users.updateUserMetadata(userId, {
+      privateMetadata: {
+        tidal: tidalTokens,
+      },
+    });
+
+    const duration = Date.now() - startTime;
+    logger.info('tidal_tokens_stored', {
+      userId,
+      connectedAt,
+      duration,
+      scopeCount: tokens.scopes.length,
+    });
+
+    return connectedAt;
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    logger.error('store_tidal_tokens_failed', {
+      userId,
+      duration,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+
+/**
+ * Check if a user has a Tidal connection
+ *
+ * @param userId - Clerk user ID
+ * @returns true if user has valid Tidal tokens
+ */
+export async function hasTidalConnection(userId: string): Promise<boolean> {
+  const tokens = await getTidalTokens(userId);
+  return tokens !== null;
+}
+
+/**
+ * Check if the user's Tidal access token is expired
+ *
+ * @param userId - Clerk user ID
+ * @returns true if expired, false if valid, null if no tokens
+ */
+export async function isTokenExpired(userId: string): Promise<boolean | null> {
+  const tokens = await getTidalTokens(userId);
+  if (!tokens) {
+    return null;
+  }
+  return Date.now() > tokens.expiresAt;
+}
+
+/**
+ * Refresh Tidal tokens for a user
+ *
+ * Updates the stored tokens after the frontend has refreshed them via the Tidal SDK.
+ * Logs success/failure with duration for observability (SC-004).
+ *
+ * @param userId - Clerk user ID
+ * @param tokens - Refreshed Tidal OAuth tokens from frontend
+ * @returns Updated token status
+ */
+export async function refreshTidalTokens(
+  userId: string,
+  tokens: TidalTokensInput
+): Promise<{ success: boolean; expiresAt: number }> {
+  const startTime = Date.now();
+
+  try {
+    // Get existing tokens to preserve connectedAt
+    const existingTokens = await getTidalTokens(userId);
+    const connectedAt = existingTokens?.connectedAt ?? Date.now();
+
+    const tidalTokens: TidalTokens = {
+      ...tokens,
+      connectedAt,
+    };
+
+    await clerkClient.users.updateUserMetadata(userId, {
+      privateMetadata: {
+        tidal: tidalTokens,
+      },
+    });
+
+    const duration = Date.now() - startTime;
+    logger.info('tidal_tokens_refreshed', {
+      userId,
+      duration,
+      expiresAt: tokens.expiresAt,
+      scopeCount: tokens.scopes.length,
+      previousExpiresAt: existingTokens?.expiresAt,
+    });
+
+    return {
+      success: true,
+      expiresAt: tokens.expiresAt,
+    };
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    logger.error('tidal_token_refresh_failed', {
+      userId,
+      duration,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+
+/**
+ * Clear Tidal tokens for a user (disconnect)
+ * Note: This is not exposed via API in the current feature scope
+ *
+ * @param userId - Clerk user ID
+ */
+export async function clearTidalTokens(userId: string): Promise<void> {
+  const startTime = Date.now();
+
+  try {
+    await clerkClient.users.updateUserMetadata(userId, {
+      privateMetadata: {
+        tidal: null,
+      },
+    });
+
+    const duration = Date.now() - startTime;
+    logger.info('tidal_tokens_cleared', {
+      userId,
+      duration,
+    });
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    logger.error('clear_tidal_tokens_failed', {
+      userId,
+      duration,
+      error: String(error),
+    });
+    throw error;
+  }
+}

--- a/backend/src/types/globals.d.ts
+++ b/backend/src/types/globals.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Type augmentations for Express Request with Clerk auth
+ *
+ * @clerk/express automatically adds auth property to Request,
+ * but we declare it explicitly for better type inference.
+ */
+
+import { AuthObject } from '@clerk/express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      /**
+       * Clerk auth object containing userId, sessionId, and claims.
+       * Populated by clerkMiddleware().
+       */
+      auth?: AuthObject;
+    }
+  }
+}
+
+export {};

--- a/backend/tests/contract/auth/authStatus.test.ts
+++ b/backend/tests/contract/auth/authStatus.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Contract tests for GET /api/auth/status endpoint
+ *
+ * Tests the authentication status endpoint response schema.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AuthStatusSchema } from '../../../src/schemas/auth.js';
+
+describe('GET /api/auth/status contract', () => {
+  describe('AuthStatusSchema', () => {
+    it('validates unauthenticated response', () => {
+      const response = {
+        isAuthenticated: false,
+        isApproved: false,
+        hasTidalConnection: false,
+      };
+
+      const result = AuthStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(false);
+        expect(result.data.isApproved).toBe(false);
+        expect(result.data.hasTidalConnection).toBe(false);
+        expect(result.data.email).toBeUndefined();
+        expect(result.data.userId).toBeUndefined();
+      }
+    });
+
+    it('validates authenticated but not approved response', () => {
+      const response = {
+        isAuthenticated: true,
+        isApproved: false,
+        hasTidalConnection: false,
+        email: 'random@example.com',
+        userId: 'user_123',
+      };
+
+      const result = AuthStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(true);
+        expect(result.data.isApproved).toBe(false);
+        expect(result.data.email).toBe('random@example.com');
+      }
+    });
+
+    it('validates approved user without Tidal response', () => {
+      const response = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: false,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_456',
+      };
+
+      const result = AuthStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isApproved).toBe(true);
+        expect(result.data.hasTidalConnection).toBe(false);
+      }
+    });
+
+    it('validates fully connected user response', () => {
+      const response = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: true,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_456',
+      };
+
+      const result = AuthStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(true);
+        expect(result.data.isApproved).toBe(true);
+        expect(result.data.hasTidalConnection).toBe(true);
+      }
+    });
+
+    it('rejects missing required fields', () => {
+      const response = {
+        isAuthenticated: true,
+        // missing isApproved and hasTidalConnection
+      };
+
+      const result = AuthStatusSchema.safeParse(response);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid email format', () => {
+      const response = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: true,
+        email: 'not-an-email',
+        userId: 'user_456',
+      };
+
+      const result = AuthStatusSchema.safeParse(response);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/backend/tests/contract/auth/tidalRefresh.test.ts
+++ b/backend/tests/contract/auth/tidalRefresh.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Contract tests for POST /api/auth/tidal/refresh endpoint
+ *
+ * Tests the Tidal token refresh endpoint response schema.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  TidalTokenStatusSchema,
+  ErrorResponseSchema,
+} from '../../../src/schemas/auth.js';
+
+describe('POST /api/auth/tidal/refresh contract', () => {
+  describe('Successful refresh response', () => {
+    it('validates token status response after refresh', () => {
+      const response = {
+        hasTokens: true,
+        expiresAt: Date.now() + 86400000, // 24 hours from now
+        isExpired: false,
+        scopes: [
+          'collection.read',
+          'playlists.read',
+          'playlists.write',
+          'recommendations.read',
+          'search.read',
+          'user.read',
+        ],
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.hasTokens).toBe(true);
+        expect(result.data.isExpired).toBe(false);
+        expect(result.data.scopes?.length).toBe(6);
+      }
+    });
+  });
+
+  describe('Error responses', () => {
+    it('validates 401 unauthorized response', () => {
+      const response = {
+        error: 'unauthorized',
+        message: 'Authentication required',
+      };
+
+      const result = ErrorResponseSchema.safeParse(response);
+      expect(result.success).toBe(true);
+    });
+
+    it('validates 403 forbidden response for non-approved user', () => {
+      const response = {
+        error: 'forbidden',
+        message: 'User not approved for beta access',
+      };
+
+      const result = ErrorResponseSchema.safeParse(response);
+      expect(result.success).toBe(true);
+    });
+
+    it('validates 422 no connection response', () => {
+      const response = {
+        error: 'no_connection',
+        message: 'No Tidal connection found',
+      };
+
+      const result = ErrorResponseSchema.safeParse(response);
+      expect(result.success).toBe(true);
+    });
+
+    it('validates 500 internal error response', () => {
+      const response = {
+        error: 'internal_error',
+        message: 'Failed to refresh Tidal tokens',
+      };
+
+      const result = ErrorResponseSchema.safeParse(response);
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/backend/tests/contract/auth/tidalTokenStatus.test.ts
+++ b/backend/tests/contract/auth/tidalTokenStatus.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Contract tests for GET /api/auth/tidal/tokens endpoint
+ *
+ * Tests the Tidal token status response schema.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TidalTokenStatusSchema } from '../../../src/schemas/auth.js';
+
+describe('GET /api/auth/tidal/tokens contract', () => {
+  describe('TidalTokenStatusSchema', () => {
+    it('validates response when no tokens exist', () => {
+      const response = {
+        hasTokens: false,
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.hasTokens).toBe(false);
+        expect(result.data.expiresAt).toBeUndefined();
+        expect(result.data.isExpired).toBeUndefined();
+        expect(result.data.scopes).toBeUndefined();
+      }
+    });
+
+    it('validates response when tokens exist and are valid', () => {
+      const futureTimestamp = Date.now() + 86400000; // 24 hours from now
+      const response = {
+        hasTokens: true,
+        expiresAt: futureTimestamp,
+        isExpired: false,
+        scopes: ['collection.read', 'playlists.read'],
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.hasTokens).toBe(true);
+        expect(result.data.expiresAt).toBe(futureTimestamp);
+        expect(result.data.isExpired).toBe(false);
+        expect(result.data.scopes).toEqual(['collection.read', 'playlists.read']);
+      }
+    });
+
+    it('validates response when tokens exist but are expired', () => {
+      const pastTimestamp = Date.now() - 86400000; // 24 hours ago
+      const response = {
+        hasTokens: true,
+        expiresAt: pastTimestamp,
+        isExpired: true,
+        scopes: ['collection.read'],
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.hasTokens).toBe(true);
+        expect(result.data.isExpired).toBe(true);
+      }
+    });
+
+    it('validates response with hasTokens true but optional fields omitted', () => {
+      // Edge case: tokens exist but we only return minimal info
+      const response = {
+        hasTokens: true,
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing hasTokens field', () => {
+      const response = {
+        expiresAt: Date.now(),
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-boolean hasTokens', () => {
+      const response = {
+        hasTokens: 'yes',
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(false);
+    });
+
+    it('validates response with empty scopes array', () => {
+      // This is technically valid per schema, though shouldn't happen in practice
+      const response = {
+        hasTokens: true,
+        expiresAt: Date.now(),
+        isExpired: false,
+        scopes: [],
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(response);
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/backend/tests/contract/auth/tidalTokens.test.ts
+++ b/backend/tests/contract/auth/tidalTokens.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Contract tests for POST /api/auth/tidal/tokens endpoint
+ *
+ * Tests the Tidal tokens storage request/response schemas.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  TidalTokensInputSchema,
+  TidalTokensResponseSchema,
+  hasRequiredScopes,
+  REQUIRED_TIDAL_SCOPES,
+} from '../../../src/schemas/auth.js';
+
+describe('POST /api/auth/tidal/tokens contract', () => {
+  describe('TidalTokensInputSchema', () => {
+    it('validates valid token input', () => {
+      const input = {
+        accessToken: 'access_token_123',
+        refreshToken: 'refresh_token_456',
+        expiresAt: Date.now() + 86400000,
+        scopes: ['collection.read', 'playlists.read'],
+      };
+
+      const result = TidalTokensInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('validates input with all required scopes', () => {
+      const input = {
+        accessToken: 'access_token_123',
+        refreshToken: 'refresh_token_456',
+        expiresAt: Date.now() + 86400000,
+        scopes: [...REQUIRED_TIDAL_SCOPES],
+      };
+
+      const result = TidalTokensInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects empty access token', () => {
+      const input = {
+        accessToken: '',
+        refreshToken: 'refresh_token_456',
+        expiresAt: Date.now() + 86400000,
+        scopes: ['collection.read'],
+      };
+
+      const result = TidalTokensInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Access token is required');
+      }
+    });
+
+    it('rejects empty refresh token', () => {
+      const input = {
+        accessToken: 'access_token_123',
+        refreshToken: '',
+        expiresAt: Date.now() + 86400000,
+        scopes: ['collection.read'],
+      };
+
+      const result = TidalTokensInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Refresh token is required');
+      }
+    });
+
+    it('rejects negative expiresAt', () => {
+      const input = {
+        accessToken: 'access_token_123',
+        refreshToken: 'refresh_token_456',
+        expiresAt: -1,
+        scopes: ['collection.read'],
+      };
+
+      const result = TidalTokensInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty scopes array', () => {
+      const input = {
+        accessToken: 'access_token_123',
+        refreshToken: 'refresh_token_456',
+        expiresAt: Date.now() + 86400000,
+        scopes: [],
+      };
+
+      const result = TidalTokensInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('At least one scope is required');
+      }
+    });
+  });
+
+  describe('TidalTokensResponseSchema', () => {
+    it('validates successful response', () => {
+      const response = {
+        success: true,
+        connectedAt: Date.now(),
+      };
+
+      const result = TidalTokensResponseSchema.safeParse(response);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing connectedAt', () => {
+      const response = {
+        success: true,
+      };
+
+      const result = TidalTokensResponseSchema.safeParse(response);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects negative connectedAt', () => {
+      const response = {
+        success: true,
+        connectedAt: -1,
+      };
+
+      const result = TidalTokensResponseSchema.safeParse(response);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('hasRequiredScopes', () => {
+    it('returns true when all required scopes are present', () => {
+      const scopes = [...REQUIRED_TIDAL_SCOPES];
+      expect(hasRequiredScopes(scopes)).toBe(true);
+    });
+
+    it('returns true when extra scopes are present', () => {
+      const scopes = [...REQUIRED_TIDAL_SCOPES, 'extra.scope'];
+      expect(hasRequiredScopes(scopes)).toBe(true);
+    });
+
+    it('returns false when a required scope is missing', () => {
+      const scopes = REQUIRED_TIDAL_SCOPES.slice(0, -1);
+      expect(hasRequiredScopes(scopes)).toBe(false);
+    });
+
+    it('returns false for empty scopes', () => {
+      expect(hasRequiredScopes([])).toBe(false);
+    });
+  });
+});

--- a/backend/tests/contract/auth/tidalTokensUnauthorized.test.ts
+++ b/backend/tests/contract/auth/tidalTokensUnauthorized.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Contract tests for 403 response on non-approved user POST /api/auth/tidal/tokens
+ *
+ * Tests that non-approved users receive a 403 Forbidden response.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ErrorResponseSchema } from '../../../src/schemas/auth.js';
+import { isApprovedUser } from '../../../src/config/allowlist.js';
+
+describe('POST /api/auth/tidal/tokens - Non-Approved User', () => {
+  describe('403 Forbidden Response', () => {
+    it('validates 403 error response schema', () => {
+      const errorResponse = {
+        error: 'forbidden',
+        message: 'User not approved for beta access',
+      };
+
+      const result = ErrorResponseSchema.safeParse(errorResponse);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.error).toBe('forbidden');
+        expect(result.data.message).toContain('not approved');
+      }
+    });
+
+    it('rejects non-approved emails', () => {
+      expect(isApprovedUser('random@example.com')).toBe(false);
+      expect(isApprovedUser('another.user@gmail.com')).toBe(false);
+      expect(isApprovedUser('admin@algojuke.com')).toBe(false);
+    });
+
+    it('only approves allowlisted emails', () => {
+      // Only anton.tcholakov@gmail.com should be approved
+      expect(isApprovedUser('anton.tcholakov@gmail.com')).toBe(true);
+
+      // Similar but different emails should fail
+      expect(isApprovedUser('anton.tcholakov@yahoo.com')).toBe(false);
+      expect(isApprovedUser('antontcholakov@gmail.com')).toBe(false);
+    });
+  });
+
+  describe('Error Response Structure', () => {
+    it('validates complete error response', () => {
+      const errorResponse = {
+        error: 'forbidden',
+        message: 'User not approved for beta access',
+      };
+
+      const result = ErrorResponseSchema.safeParse(errorResponse);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing error field', () => {
+      const errorResponse = {
+        message: 'User not approved for beta access',
+      };
+
+      const result = ErrorResponseSchema.safeParse(errorResponse);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing message field', () => {
+      const errorResponse = {
+        error: 'forbidden',
+      };
+
+      const result = ErrorResponseSchema.safeParse(errorResponse);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/backend/tests/integration/auth/approvedUserFlow.test.ts
+++ b/backend/tests/integration/auth/approvedUserFlow.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration tests for approved user auth flow
+ *
+ * Tests the complete authentication flow for approved users.
+ * Note: These tests mock Clerk and focus on the integration between components.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isApprovedUser } from '../../../src/config/allowlist.js';
+import {
+  TidalTokensInputSchema,
+  AuthStatusSchema,
+  TidalTokensSchema,
+} from '../../../src/schemas/auth.js';
+
+// Mock Clerk client for integration tests
+vi.mock('@clerk/express', () => ({
+  clerkMiddleware: () => vi.fn((req, res, next) => next()),
+  getAuth: vi.fn(() => ({ userId: 'test_user_123' })),
+  clerkClient: {
+    users: {
+      getUser: vi.fn(),
+      updateUserMetadata: vi.fn(),
+    },
+  },
+}));
+
+describe('Approved User Auth Flow Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Allowlist verification', () => {
+    it('approves anton.tcholakov@gmail.com', () => {
+      expect(isApprovedUser('anton.tcholakov@gmail.com')).toBe(true);
+    });
+
+    it('approves email case-insensitively', () => {
+      expect(isApprovedUser('Anton.Tcholakov@Gmail.com')).toBe(true);
+      expect(isApprovedUser('ANTON.TCHOLAKOV@GMAIL.COM')).toBe(true);
+    });
+
+    it('rejects non-approved emails', () => {
+      expect(isApprovedUser('random@example.com')).toBe(false);
+      expect(isApprovedUser('notanton@gmail.com')).toBe(false);
+    });
+  });
+
+  describe('Token storage flow', () => {
+    it('validates and stores tokens correctly', () => {
+      // Simulate token input from frontend
+      const frontendTokens = {
+        accessToken: 'tidal_access_token_xyz',
+        refreshToken: 'tidal_refresh_token_abc',
+        expiresAt: Date.now() + 86400000,
+        scopes: [
+          'collection.read',
+          'playlists.read',
+          'playlists.write',
+          'recommendations.read',
+          'search.read',
+          'user.read',
+        ],
+      };
+
+      // Validate input
+      const inputResult = TidalTokensInputSchema.safeParse(frontendTokens);
+      expect(inputResult.success).toBe(true);
+
+      // Create stored tokens (with connectedAt)
+      const storedTokens = {
+        ...frontendTokens,
+        connectedAt: Date.now(),
+      };
+
+      // Validate stored format
+      const storageResult = TidalTokensSchema.safeParse(storedTokens);
+      expect(storageResult.success).toBe(true);
+    });
+
+    it('produces correct auth status after connection', () => {
+      const authStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: true,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_123',
+      };
+
+      const result = AuthStatusSchema.safeParse(authStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(true);
+        expect(result.data.isApproved).toBe(true);
+        expect(result.data.hasTidalConnection).toBe(true);
+      }
+    });
+  });
+
+  describe('User state transitions', () => {
+    it('tracks state: Unauthenticated → Authenticated → Approved → Connected', () => {
+      // State 1: Unauthenticated
+      const unauthenticated = {
+        isAuthenticated: false,
+        isApproved: false,
+        hasTidalConnection: false,
+      };
+      expect(AuthStatusSchema.parse(unauthenticated).isAuthenticated).toBe(false);
+
+      // State 2: Authenticated but not approved (this user should go to waitlist)
+      const authenticatedNotApproved = {
+        isAuthenticated: true,
+        isApproved: false,
+        hasTidalConnection: false,
+        email: 'random@example.com',
+        userId: 'user_random',
+      };
+      expect(AuthStatusSchema.parse(authenticatedNotApproved).isApproved).toBe(false);
+
+      // State 3: Approved but no Tidal
+      const approvedNoTidal = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: false,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_anton',
+      };
+      const parsed = AuthStatusSchema.parse(approvedNoTidal);
+      expect(parsed.isApproved).toBe(true);
+      expect(parsed.hasTidalConnection).toBe(false);
+
+      // State 4: Fully connected
+      const connected = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: true,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_anton',
+      };
+      const connectedParsed = AuthStatusSchema.parse(connected);
+      expect(connectedParsed.isAuthenticated).toBe(true);
+      expect(connectedParsed.isApproved).toBe(true);
+      expect(connectedParsed.hasTidalConnection).toBe(true);
+    });
+  });
+});

--- a/backend/tests/integration/auth/incompleteTidalFlow.test.ts
+++ b/backend/tests/integration/auth/incompleteTidalFlow.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration tests for incomplete Tidal flow
+ *
+ * Tests the user experience when Tidal connection is interrupted.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  AuthStatusSchema,
+  TidalTokenStatusSchema,
+} from '../../../src/schemas/auth.js';
+import { isApprovedUser } from '../../../src/config/allowlist.js';
+
+describe('Incomplete Tidal Flow Integration', () => {
+  describe('Approved user without Tidal connection', () => {
+    it('identifies approved user state correctly', () => {
+      // Approved user who has not completed Tidal connection
+      const authStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: false,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_123',
+      };
+
+      const result = AuthStatusSchema.safeParse(authStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(true);
+        expect(result.data.isApproved).toBe(true);
+        expect(result.data.hasTidalConnection).toBe(false);
+      }
+    });
+
+    it('returns no tokens for user without Tidal connection', () => {
+      const tokenStatus = {
+        hasTokens: false,
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(tokenStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.hasTokens).toBe(false);
+        expect(result.data.expiresAt).toBeUndefined();
+        expect(result.data.scopes).toBeUndefined();
+      }
+    });
+  });
+
+  describe('Returning user flow', () => {
+    it('user approval persists across sessions', () => {
+      // User was approved in previous session
+      expect(isApprovedUser('anton.tcholakov@gmail.com')).toBe(true);
+
+      // Auth status shows approved but no Tidal
+      const authStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: false,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_456',
+      };
+
+      const result = AuthStatusSchema.safeParse(authStatus);
+      expect(result.success).toBe(true);
+    });
+
+    it('handles transition from no tokens to connected', () => {
+      // State before connection
+      const beforeConnection = {
+        hasTokens: false,
+      };
+      expect(TidalTokenStatusSchema.parse(beforeConnection).hasTokens).toBe(false);
+
+      // State after connection
+      const afterConnection = {
+        hasTokens: true,
+        expiresAt: Date.now() + 86400000,
+        isExpired: false,
+        scopes: ['collection.read', 'playlists.read'],
+      };
+      const parsed = TidalTokenStatusSchema.parse(afterConnection);
+      expect(parsed.hasTokens).toBe(true);
+      expect(parsed.isExpired).toBe(false);
+    });
+  });
+
+  describe('OAuth cancellation scenarios', () => {
+    it('handles cancelled OAuth flow', () => {
+      // User cancelled OAuth - returns to approved but no Tidal state
+      const authStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: false,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_789',
+      };
+
+      const result = AuthStatusSchema.safeParse(authStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.hasTidalConnection).toBe(false);
+      }
+    });
+
+    it('handles failed OAuth with retry option', () => {
+      // After failed OAuth attempt, status remains approved without Tidal
+      // User should be able to retry connection
+      const tokenStatus = {
+        hasTokens: false,
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(tokenStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.hasTokens).toBe(false);
+        // Frontend should show retry button based on this state
+      }
+    });
+  });
+});

--- a/backend/tests/integration/auth/sessionPersistence.test.ts
+++ b/backend/tests/integration/auth/sessionPersistence.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration tests for session persistence
+ *
+ * Tests that Clerk session survives browser refresh (FR-012).
+ *
+ * Note: These are contract-level tests validating the session data structure.
+ * Actual browser refresh behavior is handled by Clerk SDK and requires E2E testing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AuthStatusSchema,
+  TidalTokenStatusSchema,
+} from '../../../src/schemas/auth.js';
+import { isApprovedUser } from '../../../src/config/allowlist.js';
+
+describe('Session Persistence Integration', () => {
+  describe('Auth status across requests', () => {
+    it('returns consistent auth status for authenticated user', () => {
+      // Simulates multiple requests from same authenticated session
+      const authStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: true,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_persistent_123',
+      };
+
+      // First request
+      const result1 = AuthStatusSchema.safeParse(authStatus);
+      expect(result1.success).toBe(true);
+
+      // Second request (simulating page refresh - same data returned)
+      const result2 = AuthStatusSchema.safeParse(authStatus);
+      expect(result2.success).toBe(true);
+
+      // Results should be identical
+      if (result1.success && result2.success) {
+        expect(result1.data.userId).toBe(result2.data.userId);
+        expect(result1.data.isAuthenticated).toBe(result2.data.isAuthenticated);
+        expect(result1.data.isApproved).toBe(result2.data.isApproved);
+      }
+    });
+
+    it('maintains approval status across session', () => {
+      const email = 'anton.tcholakov@gmail.com';
+
+      // Approval status is deterministic based on allowlist
+      const firstCheck = isApprovedUser(email);
+      const secondCheck = isApprovedUser(email);
+
+      expect(firstCheck).toBe(true);
+      expect(secondCheck).toBe(true);
+      expect(firstCheck).toBe(secondCheck);
+    });
+  });
+
+  describe('Tidal token persistence', () => {
+    it('maintains Tidal connection status across requests', () => {
+      // Tidal tokens stored in Clerk metadata persist across sessions
+      const tokenStatus = {
+        hasTokens: true,
+        expiresAt: Date.now() + 86400000, // 24 hours
+        isExpired: false,
+        scopes: ['collection.read', 'playlists.read', 'user.read'],
+      };
+
+      // First request
+      const result1 = TidalTokenStatusSchema.safeParse(tokenStatus);
+      expect(result1.success).toBe(true);
+
+      // Subsequent request (after refresh)
+      const result2 = TidalTokenStatusSchema.safeParse(tokenStatus);
+      expect(result2.success).toBe(true);
+
+      if (result1.success && result2.success) {
+        expect(result1.data.hasTokens).toBe(result2.data.hasTokens);
+        expect(result1.data.expiresAt).toBe(result2.data.expiresAt);
+      }
+    });
+
+    it('detects expired tokens correctly after session resume', () => {
+      // Simulates returning to app after token expiration
+      const expiredTokenStatus = {
+        hasTokens: true,
+        expiresAt: Date.now() - 3600000, // 1 hour ago
+        isExpired: true,
+        scopes: ['collection.read'],
+      };
+
+      const result = TidalTokenStatusSchema.safeParse(expiredTokenStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isExpired).toBe(true);
+      }
+    });
+  });
+
+  describe('Session state transitions', () => {
+    it('handles unauthenticated state correctly', () => {
+      // Before sign-in or after sign-out
+      const unauthStatus = {
+        isAuthenticated: false,
+        isApproved: false,
+        hasTidalConnection: false,
+      };
+
+      const result = AuthStatusSchema.safeParse(unauthStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(false);
+        expect(result.data.email).toBeUndefined();
+        expect(result.data.userId).toBeUndefined();
+      }
+    });
+
+    it('handles authenticated but not approved state', () => {
+      // Non-allowlisted user
+      const notApprovedStatus = {
+        isAuthenticated: true,
+        isApproved: false,
+        hasTidalConnection: false,
+        email: 'random.user@example.com',
+        userId: 'user_random_456',
+      };
+
+      const result = AuthStatusSchema.safeParse(notApprovedStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(true);
+        expect(result.data.isApproved).toBe(false);
+      }
+    });
+
+    it('handles authenticated and approved but no Tidal state', () => {
+      // Approved user who hasn't connected Tidal yet
+      const noTidalStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: false,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_approved_789',
+      };
+
+      const result = AuthStatusSchema.safeParse(noTidalStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(true);
+        expect(result.data.isApproved).toBe(true);
+        expect(result.data.hasTidalConnection).toBe(false);
+      }
+    });
+
+    it('handles fully connected state', () => {
+      // Full access user
+      const fullyConnectedStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: true,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_full_101',
+      };
+
+      const result = AuthStatusSchema.safeParse(fullyConnectedStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.isAuthenticated).toBe(true);
+        expect(result.data.isApproved).toBe(true);
+        expect(result.data.hasTidalConnection).toBe(true);
+      }
+    });
+  });
+
+  describe('Clerk session validation', () => {
+    it('session contains required fields for routing decisions', () => {
+      // Frontend routing depends on these fields
+      const authStatus = {
+        isAuthenticated: true,
+        isApproved: true,
+        hasTidalConnection: false,
+        email: 'anton.tcholakov@gmail.com',
+        userId: 'user_route_202',
+      };
+
+      const result = AuthStatusSchema.safeParse(authStatus);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // ProtectedRoute uses these to determine redirect
+        expect(typeof result.data.isAuthenticated).toBe('boolean');
+        expect(typeof result.data.isApproved).toBe('boolean');
+        expect(typeof result.data.hasTidalConnection).toBe('boolean');
+      }
+    });
+
+    it('session fields are nullable for unauthenticated users', () => {
+      const unauthStatus = {
+        isAuthenticated: false,
+        isApproved: false,
+        hasTidalConnection: false,
+      };
+
+      const result = AuthStatusSchema.safeParse(unauthStatus);
+      expect(result.success).toBe(true);
+      // email and userId should not be present for unauthenticated users
+      if (result.success) {
+        expect(result.data.email).toBeUndefined();
+        expect(result.data.userId).toBeUndefined();
+      }
+    });
+  });
+});

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+# Frontend Environment Variables
+
+# API
+VITE_API_URL=http://localhost:4000
+
+# Clerk Authentication
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_...
+
+# Tidal OAuth
+VITE_TIDAL_CLIENT_ID=your_tidal_client_id
+VITE_TIDAL_REDIRECT_URI=https://localhost:5173/auth/tidal/callback

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,160 @@
+# AlgoJuke Frontend
+
+React frontend for AI-powered music discovery with Tidal integration.
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js 20.x or higher
+- Clerk account with Google OAuth enabled
+- Tidal Developer account
+- HTTPS for development (required by Tidal OAuth)
+
+### Installation
+
+```bash
+cd frontend
+npm install
+```
+
+### Environment Setup
+
+Copy the example environment file:
+
+```bash
+cp .env.example .env
+```
+
+Configure the following required variables:
+
+| Variable | Description |
+|----------|-------------|
+| `VITE_CLERK_PUBLISHABLE_KEY` | Clerk publishable key (pk_test_...) |
+| `VITE_TIDAL_CLIENT_ID` | Tidal API client ID |
+| `VITE_TIDAL_REDIRECT_URI` | OAuth callback URL (https://localhost:5173/auth/tidal/callback) |
+| `VITE_API_URL` | Backend API URL (http://localhost:4000) |
+
+### Running the Development Server
+
+```bash
+npm run dev
+```
+
+The app will be available at https://localhost:5173 (HTTPS is required for Tidal OAuth).
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run auth tests only
+npm test -- tests/components/auth
+
+# Type checking
+npm run type-check
+```
+
+## Authentication Flow
+
+The app uses a three-tier authentication flow:
+
+1. **Landing Page** (`/`): Public page with "Sign in with Google" button
+2. **Clerk OAuth**: User signs in with Google via Clerk
+3. **Allowlist Check**:
+   - If approved → Tidal Connect Page
+   - If not approved → Waitlist Page
+4. **Tidal OAuth**: User connects their Tidal account
+5. **Main App** (`/discover`): Full access to music discovery features
+
+### Auth Routes
+
+| Route | Component | Access |
+|-------|-----------|--------|
+| `/` | LandingPage | Public |
+| `/waitlist` | WaitlistPage | Authenticated (non-approved) |
+| `/connect-tidal` | TidalConnectPage | Authenticated + Approved |
+| `/auth/tidal/callback` | CallbackPage | Authenticated + Approved |
+| `/discover` | DiscoverChat | Fully Connected |
+
+### Key Components
+
+| Component | Purpose |
+|-----------|---------|
+| `ProtectedRoute` | Route guard checking auth/approval/Tidal status |
+| `TidalConnectButton` | Initiates Tidal OAuth flow |
+| `AuthLayout` | Centered layout for auth pages |
+
+### Key Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `useTidalAuth` | Manages Tidal SDK state and OAuth flow |
+
+## Project Structure
+
+```
+frontend/
+├── src/
+│   ├── components/
+│   │   ├── auth/
+│   │   │   ├── ProtectedRoute.tsx
+│   │   │   └── TidalConnectButton.tsx
+│   │   ├── layout/
+│   │   │   └── AuthLayout.tsx
+│   │   └── ErrorBoundary.tsx
+│   ├── hooks/
+│   │   └── useTidalAuth.ts
+│   ├── pages/
+│   │   ├── LandingPage.tsx
+│   │   ├── WaitlistPage.tsx
+│   │   ├── TidalConnectPage.tsx
+│   │   ├── CallbackPage.tsx
+│   │   └── DiscoverChat.tsx
+│   ├── App.tsx
+│   └── main.tsx
+├── tests/
+│   └── components/auth/
+└── package.json
+```
+
+## Troubleshooting
+
+### "Insecure context" Error from Tidal SDK
+
+Tidal OAuth requires HTTPS. The Vite config is set up for HTTPS by default:
+
+```typescript
+// vite.config.ts
+server: {
+  https: true,
+  port: 5173,
+}
+```
+
+If you see this error:
+1. Ensure you're accessing https://localhost:5173 (not http://)
+2. Accept the self-signed certificate warning in your browser
+
+### "Invalid redirect URI" from Tidal
+
+1. Verify the redirect URI in Tidal Developer Portal matches exactly
+2. The URI should be: `https://localhost:5173/auth/tidal/callback`
+3. Include the full path, not just the domain
+
+### User Stuck on Waitlist
+
+The user's email is not in the backend allowlist. Add their email to `backend/src/config/allowlist.ts`.
+
+### OAuth Callback Errors
+
+1. Check the URL for error parameters (e.g., `?error=access_denied`)
+2. Ensure the Tidal app has the correct scopes configured
+3. Verify the user has an active Tidal subscription
+
+### Sign-Out Not Working
+
+The UserButton from Clerk handles sign-out. If it's not visible:
+1. Ensure the user is signed in
+2. Check that ClerkProvider wraps the app in `main.tsx`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@apollo/client": "^3.8.9",
+        "@clerk/clerk-react": "^5.59.2",
+        "@tidal-music/auth": "^1.4.0",
         "@types/react-window": "^1.8.8",
         "graphql": "^16.8.1",
         "react": "^18.2.0",
@@ -27,6 +29,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
+        "@vitejs/plugin-basic-ssl": "^1.1.0",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/coverage-v8": "^1.2.0",
         "eslint": "^8.56.0",
@@ -451,6 +454,59 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.59.2.tgz",
+      "integrity": "sha512-vFZ4LWPenbNnui4GqGGkicH/3SL7KhS9egTMv/m0Dj/sS7mUgmLqAFpqWkhbzN8s8/rybuvJsMyIU7M0kx8+Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.41.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.41.1.tgz",
+      "integrity": "sha512-BCbT7Xodk2rndA2nV/lW8X5LMNTvFP5UG2wNN9cYuAcTaI6hYZP18/z2zef2gG4xIrK7WAEjGVzHscikqNtzFQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/shared/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
@@ -1661,6 +1717,35 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tidal-music/auth": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@tidal-music/auth/-/auth-1.4.0.tgz",
+      "integrity": "sha512-b/8n6aHYoMuzGbNTT4QOwm9xjTosHCn9F+Vi26Nq1x1OuK+XK9zbuAkSwma/C5eYHy4fPBTcSw82us5K5mUHmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tidal-music/auth": "1.4.0",
+        "@tidal-music/common": "^0.2.0",
+        "@tidal-music/true-time": "^0.3.0"
+      }
+    },
+    "node_modules/@tidal-music/common": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tidal-music/common/-/common-0.2.0.tgz",
+      "integrity": "sha512-XBNzRiN6rRQL0gu5cIigMdSQy1U4zEx5nJ9caaIACNXSu+RGGkYpoxWp8CBJTHtkQ3oSF2SMugNEo71i8LPP3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tidal-music/common": "0.2.0"
+      }
+    },
+    "node_modules/@tidal-music/true-time": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tidal-music/true-time/-/true-time-0.3.0.tgz",
+      "integrity": "sha512-nO9DfLKLu5sCI/v6Yp8DSseu8qis0RI1r6l7oIFCusOAedkIbQT/K+ELaaz7cxXR4cboopUZGW55v4RVwxHE/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tidal-music/true-time": "0.3.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2049,6 +2134,19 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.1.0.tgz",
+      "integrity": "sha512-wO4Dk/rm8u7RNhOf95ZzcEmC9rYOncYgvq4z3duaJrCgjN8BxAnDVyndanfcJZ0O6XZzHz6Q0hTimxTg8Y9g/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6.0"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -4280,6 +4378,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5292,6 +5396,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -7597,7 +7710,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -7840,6 +7952,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-observable": {
@@ -8325,6 +8450,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vfile": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.9",
+    "@clerk/clerk-react": "^5.59.2",
+    "@tidal-music/auth": "^1.4.0",
     "@types/react-window": "^1.8.8",
     "graphql": "^16.8.1",
     "react": "^18.2.0",
@@ -33,6 +35,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
+    "@vitejs/plugin-basic-ssl": "^1.1.0",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^1.2.0",
     "eslint": "^8.56.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,11 @@ import { AppHeader } from './components/AppHeader';
 import { SearchPage } from './pages/SearchPage';
 import { LibraryPage } from './pages/LibraryPage';
 import { DiscoverPage } from './pages/DiscoverPage';
+import { LandingPage } from './pages/LandingPage';
+import { TidalConnectPage } from './pages/TidalConnectPage';
+import { CallbackPage } from './pages/CallbackPage';
+import { WaitlistPage } from './pages/WaitlistPage';
+import { ProtectedRoute } from './components/auth/ProtectedRoute';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import './App.css';
 
@@ -17,11 +22,50 @@ export function App() {
         <UndoDeleteProvider>
           <BrowserRouter>
             <Toaster position="bottom-right" richColors />
-            <AppHeader />
             <Routes>
-              <Route path="/" element={<SearchPage />} />
-              <Route path="/discover/*" element={<DiscoverPage />} />
-              <Route path="/library/*" element={<LibraryPage />} />
+              {/* Public routes */}
+              <Route path="/" element={<LandingPage />} />
+              <Route path="/waitlist" element={<WaitlistPage />} />
+              <Route path="/auth/tidal/callback" element={<CallbackPage />} />
+
+              {/* Approved user route (requires auth but not Tidal) */}
+              <Route
+                path="/connect-tidal"
+                element={
+                  <ProtectedRoute requireTidal={false}>
+                    <TidalConnectPage />
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* Protected routes (require auth + Tidal) */}
+              <Route
+                path="/search"
+                element={
+                  <ProtectedRoute requireTidal>
+                    <AppHeader />
+                    <SearchPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/discover/*"
+                element={
+                  <ProtectedRoute requireTidal>
+                    <AppHeader />
+                    <DiscoverPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/library/*"
+                element={
+                  <ProtectedRoute requireTidal>
+                    <AppHeader />
+                    <LibraryPage />
+                  </ProtectedRoute>
+                }
+              />
             </Routes>
           </BrowserRouter>
         </UndoDeleteProvider>

--- a/frontend/src/components/AppHeader.css
+++ b/frontend/src/components/AppHeader.css
@@ -9,8 +9,12 @@
   max-width: 1200px;
   margin: 0 auto;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 2rem;
+}
+
+.app-header-user {
+  margin-left: auto;
 }
 
 .app-title {

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom';
+import { UserButton } from '@clerk/clerk-react';
 import './AppHeader.css';
 
 export function AppHeader() {
@@ -8,7 +9,7 @@ export function AppHeader() {
         <h1 className="app-title">AlgoJuke</h1>
         <nav className="app-nav">
           <NavLink
-            to="/"
+            to="/search"
             className={({ isActive }) => isActive ? 'app-nav-link active' : 'app-nav-link'}
           >
             Search
@@ -26,6 +27,9 @@ export function AppHeader() {
             Library
           </NavLink>
         </nav>
+        <div className="app-header-user">
+          <UserButton afterSignOutUrl="/" />
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,153 @@
+/**
+ * Protected Route Component
+ *
+ * Guards routes based on authentication and authorization state.
+ * Redirects users to appropriate pages based on their access level.
+ */
+
+import { ReactNode, useEffect, useState, useCallback } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useUser, useAuth } from '@clerk/clerk-react';
+import { useTidalAuth } from '../../hooks/useTidalAuth';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+  /**
+   * If true, requires the user to have connected their Tidal account
+   */
+  requireTidal?: boolean;
+}
+
+interface AuthStatus {
+  isAuthenticated: boolean;
+  isApproved: boolean;
+  hasTidalConnection: boolean;
+  tidalTokenExpired?: boolean;
+}
+
+/**
+ * Route guard that checks authentication, approval status, and Tidal connection.
+ *
+ * Redirect logic:
+ * - Not signed in → Landing page (/)
+ * - Signed in but not approved → Waitlist page (/waitlist)
+ * - Approved but no Tidal connection (when requireTidal=true) → Connect page (/connect-tidal)
+ * - Token expired → Attempt refresh via SDK
+ * - Otherwise → Render children
+ */
+export function ProtectedRoute({
+  children,
+  requireTidal = false,
+}: ProtectedRouteProps): ReactNode {
+  const { isLoaded, isSignedIn } = useUser();
+  const { getToken } = useAuth();
+  const location = useLocation();
+  const { refreshAndSyncToken, isInitialized: tidalSdkReady } = useTidalAuth();
+
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshFailed, setRefreshFailed] = useState(false);
+
+  const checkAuthStatus = useCallback(async () => {
+    if (!isLoaded || !isSignedIn) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const token = await getToken();
+      const response = await fetch('/api/auth/status', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        const status: AuthStatus = await response.json();
+        setAuthStatus(status);
+
+        // If token is expired and we have Tidal SDK ready, try to refresh
+        if (status.tidalTokenExpired && tidalSdkReady && !isRefreshing && !refreshFailed) {
+          setIsRefreshing(true);
+          const refreshSuccess = await refreshAndSyncToken();
+          setIsRefreshing(false);
+
+          if (refreshSuccess) {
+            // Re-check auth status after successful refresh
+            const refreshedResponse = await fetch('/api/auth/status', {
+              headers: { Authorization: `Bearer ${token}` },
+            });
+            if (refreshedResponse.ok) {
+              setAuthStatus(await refreshedResponse.json());
+            }
+          } else {
+            setRefreshFailed(true);
+          }
+        }
+      }
+    } catch {
+      // Ignore errors
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoaded, isSignedIn, getToken, tidalSdkReady, isRefreshing, refreshFailed, refreshAndSyncToken]);
+
+  useEffect(() => {
+    checkAuthStatus();
+  }, [checkAuthStatus]);
+
+  // Show loading state while checking auth
+  if (!isLoaded || isLoading) {
+    return (
+      <div className="auth-loading">
+        <div className="spinner" />
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  // Not signed in → Landing page
+  if (!isSignedIn) {
+    return <Navigate to="/" state={{ from: location }} replace />;
+  }
+
+  // Still fetching auth status
+  if (!authStatus) {
+    return (
+      <div className="auth-loading">
+        <div className="spinner" />
+        <p>Checking authorization...</p>
+      </div>
+    );
+  }
+
+  // Refreshing token
+  if (isRefreshing) {
+    return (
+      <div className="auth-loading">
+        <div className="spinner" />
+        <p>Refreshing Tidal connection...</p>
+      </div>
+    );
+  }
+
+  // Token refresh failed - need to reconnect
+  if (refreshFailed) {
+    return <Navigate to="/connect-tidal" state={{ returnTo: location.pathname }} replace />;
+  }
+
+  // Signed in but not approved → Waitlist
+  if (!authStatus.isApproved) {
+    return <Navigate to="/waitlist" state={{ from: location }} replace />;
+  }
+
+  // Approved but no Tidal connection (when required) → Connect page
+  // Pass through the original destination URL
+  if (requireTidal && !authStatus.hasTidalConnection) {
+    return <Navigate to="/connect-tidal" state={{ returnTo: location.pathname }} replace />;
+  }
+
+  // All checks passed → Render children
+  return <>{children}</>;
+}

--- a/frontend/src/components/auth/TidalConnectButton.tsx
+++ b/frontend/src/components/auth/TidalConnectButton.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tidal Connect Button
+ *
+ * Button component that initiates the Tidal OAuth flow.
+ */
+
+import { useTidalAuth } from '../../hooks/useTidalAuth';
+
+interface TidalConnectButtonProps {
+  disabled?: boolean;
+  /** Called before initiating OAuth, useful for saving return URL */
+  onBeforeConnect?: () => void;
+}
+
+export function TidalConnectButton({
+  disabled = false,
+  onBeforeConnect,
+}: TidalConnectButtonProps): JSX.Element {
+  const { initiateTidalLogin, isConnecting, isInitialized } = useTidalAuth();
+
+  const handleClick = async () => {
+    onBeforeConnect?.();
+    await initiateTidalLogin();
+  };
+
+  const buttonDisabled = disabled || isConnecting || !isInitialized;
+
+  return (
+    <button
+      className="auth-button"
+      onClick={handleClick}
+      disabled={buttonDisabled}
+      type="button"
+    >
+      {isConnecting ? (
+        <>
+          <span className="spinner spinner--small" />
+          Connecting...
+        </>
+      ) : (
+        <>
+          <TidalIcon />
+          Connect with Tidal
+        </>
+      )}
+    </button>
+  );
+}
+
+/**
+ * Tidal logo icon
+ */
+function TidalIcon(): JSX.Element {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M12 0L8 4L12 8L16 4L12 0Z" />
+      <path d="M4 8L0 12L4 16L8 12L4 8Z" />
+      <path d="M12 8L8 12L12 16L16 12L12 8Z" />
+      <path d="M20 8L16 12L20 16L24 12L20 8Z" />
+      <path d="M12 16L8 20L12 24L16 20L12 16Z" />
+    </svg>
+  );
+}

--- a/frontend/src/components/layout/AuthLayout.css
+++ b/frontend/src/components/layout/AuthLayout.css
@@ -1,0 +1,198 @@
+/**
+ * Auth Layout Styles
+ *
+ * Styles for authentication-related pages.
+ */
+
+.auth-layout {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  padding: 2rem;
+}
+
+.auth-container {
+  width: 100%;
+  max-width: 480px;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 2rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.auth-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.auth-logo {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #fff;
+  margin: 0 0 0.5rem 0;
+  letter-spacing: -0.02em;
+}
+
+.auth-beta-badge {
+  display: inline-block;
+  background: linear-gradient(135deg, #e94560 0%, #ff6b6b 100%);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 100px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.auth-content {
+  color: #e0e0e0;
+}
+
+.auth-content h2 {
+  color: #fff;
+  font-size: 1.5rem;
+  margin: 0 0 1rem 0;
+  text-align: center;
+}
+
+.auth-content p {
+  line-height: 1.6;
+  margin: 0 0 1rem 0;
+  text-align: center;
+}
+
+.auth-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-align: center;
+}
+
+.auth-footer p {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+/* Loading state */
+.auth-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: #e0e0e0;
+}
+
+.auth-loading .spinner,
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  border-top-color: #e94560;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+/* Small spinner for buttons */
+.spinner--small {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+  margin-bottom: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Buttons */
+.auth-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.875rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, #e94560 0%, #ff6b6b 100%);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.auth-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(233, 69, 96, 0.4);
+}
+
+.auth-button:active {
+  transform: translateY(0);
+}
+
+.auth-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.auth-button--secondary {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.auth-button--secondary:hover {
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 4px 20px rgba(255, 255, 255, 0.1);
+}
+
+/* Error message */
+.auth-error {
+  background: rgba(233, 69, 96, 0.1);
+  border: 1px solid rgba(233, 69, 96, 0.3);
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 1rem 0;
+  color: #ff6b6b;
+  text-align: center;
+}
+
+/* Feature list */
+.auth-features {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.auth-features li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  color: #e0e0e0;
+}
+
+.auth-features li::before {
+  content: '✓';
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: rgba(233, 69, 96, 0.2);
+  color: #e94560;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: bold;
+}

--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -1,0 +1,33 @@
+/**
+ * Auth Layout Component
+ *
+ * Layout wrapper for authentication-related pages (landing, waitlist, connect).
+ * Provides consistent styling and branding for the auth flow.
+ */
+
+import { ReactNode } from 'react';
+import './AuthLayout.css';
+
+interface AuthLayoutProps {
+  children: ReactNode;
+}
+
+/**
+ * Centered layout for auth pages with AlgoJuke branding
+ */
+export function AuthLayout({ children }: AuthLayoutProps): ReactNode {
+  return (
+    <div className="auth-layout">
+      <div className="auth-container">
+        <header className="auth-header">
+          <h1 className="auth-logo">AlgoJuke</h1>
+          <span className="auth-beta-badge">Private Beta</span>
+        </header>
+        <main className="auth-content">{children}</main>
+        <footer className="auth-footer">
+          <p>&copy; {new Date().getFullYear()} AlgoJuke. All rights reserved.</p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTidalAuth.ts
+++ b/frontend/src/hooks/useTidalAuth.ts
@@ -1,0 +1,278 @@
+/**
+ * Tidal Auth Hook
+ *
+ * Manages Tidal SDK authentication state and token storage.
+ * The Tidal SDK handles token refresh internally - this hook syncs
+ * tokens to the backend for server-side API calls.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import {
+  init,
+  initializeLogin,
+  finalizeLogin,
+  credentialsProvider,
+} from '@tidal-music/auth';
+
+// Tidal OAuth configuration
+const TIDAL_CLIENT_ID = import.meta.env.VITE_TIDAL_CLIENT_ID;
+const TIDAL_REDIRECT_URI = import.meta.env.VITE_TIDAL_REDIRECT_URI;
+
+// Required scopes for AlgoJuke
+const TIDAL_SCOPES = [
+  'user.read',
+  'collection.read',
+  'playlists.read',
+  'playlists.write',
+  'recommendations.read',
+  'search.read',
+];
+
+export interface TidalAuthState {
+  isInitialized: boolean;
+  isConnecting: boolean;
+  isConnected: boolean;
+  error: string | null;
+}
+
+export interface UseTidalAuthReturn extends TidalAuthState {
+  initiateTidalLogin: () => Promise<void>;
+  finalizeTidalLogin: (callbackUrl: string) => Promise<boolean>;
+  checkConnection: () => Promise<boolean>;
+  refreshAndSyncToken: () => Promise<boolean>;
+}
+
+/**
+ * Hook for managing Tidal authentication
+ */
+export function useTidalAuth(): UseTidalAuthReturn {
+  const { getToken } = useAuth();
+  const [state, setState] = useState<TidalAuthState>({
+    isInitialized: false,
+    isConnecting: false,
+    isConnected: false,
+    error: null,
+  });
+
+  // Initialize Tidal SDK on mount
+  useEffect(() => {
+    if (!TIDAL_CLIENT_ID) {
+      setState((prev) => ({
+        ...prev,
+        error: 'Missing VITE_TIDAL_CLIENT_ID environment variable',
+      }));
+      return;
+    }
+
+    async function initializeSdk() {
+      try {
+        await init({
+          clientId: TIDAL_CLIENT_ID,
+          credentialsStorageKey: 'algojuke-tidal-auth',
+          scopes: TIDAL_SCOPES,
+        });
+        setState((prev) => ({ ...prev, isInitialized: true }));
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          error: `Failed to initialize Tidal SDK: ${error}`,
+        }));
+      }
+    }
+
+    initializeSdk();
+  }, []);
+
+  /**
+   * Check if user has a Tidal connection by querying the backend
+   */
+  const checkConnection = useCallback(async (): Promise<boolean> => {
+    try {
+      const token = await getToken();
+      const response = await fetch('/api/auth/status', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        return false;
+      }
+
+      const data = await response.json();
+      const connected = data.hasTidalConnection === true;
+      setState((prev) => ({ ...prev, isConnected: connected }));
+      return connected;
+    } catch {
+      return false;
+    }
+  }, [getToken]);
+
+  /**
+   * Start the Tidal OAuth login flow
+   */
+  const initiateTidalLogin = useCallback(async (): Promise<void> => {
+    if (!state.isInitialized) {
+      setState((prev) => ({
+        ...prev,
+        error: 'Tidal SDK not initialized',
+      }));
+      return;
+    }
+
+    if (!TIDAL_REDIRECT_URI) {
+      setState((prev) => ({
+        ...prev,
+        error: 'Missing VITE_TIDAL_REDIRECT_URI environment variable',
+      }));
+      return;
+    }
+
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+
+    try {
+      const loginUrl = await initializeLogin({
+        redirectUri: TIDAL_REDIRECT_URI,
+      });
+
+      // Redirect to Tidal OAuth
+      window.location.href = loginUrl;
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isConnecting: false,
+        error: `Failed to start Tidal login: ${error}`,
+      }));
+    }
+  }, [state.isInitialized]);
+
+  /**
+   * Sync current SDK credentials to backend.
+   * The SDK automatically refreshes tokens when getCredentials() is called.
+   */
+  const syncTokensToBackend = useCallback(
+    async (credentials: { token?: string; expires?: number; grantedScopes?: string[] }): Promise<boolean> => {
+      if (!credentials.token) {
+        return false;
+      }
+      const clerkToken = await getToken();
+
+      const expiresAt = credentials.expires
+        ? credentials.expires
+        : Date.now() + 3600000; // Default 1h if not provided
+
+      const response = await fetch('/api/auth/tidal/tokens', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${clerkToken}`,
+        },
+        body: JSON.stringify({
+          accessToken: credentials.token,
+          // SDK manages refresh internally - we store a placeholder
+          // Frontend is responsible for refreshing via SDK and syncing
+          refreshToken: `sdk-managed-${Date.now()}`,
+          expiresAt,
+          scopes: credentials.grantedScopes || TIDAL_SCOPES,
+        }),
+      });
+
+      return response.ok;
+    },
+    [getToken]
+  );
+
+  /**
+   * Refresh token via SDK and sync to backend.
+   * Call this when backend reports token is expired.
+   */
+  const refreshAndSyncToken = useCallback(async (): Promise<boolean> => {
+    if (!state.isInitialized) {
+      return false;
+    }
+
+    try {
+      // SDK automatically refreshes token if expired
+      const credentials = await credentialsProvider.getCredentials();
+
+      if (!credentials || !credentials.token) {
+        setState((prev) => ({
+          ...prev,
+          isConnected: false,
+          error: 'Tidal session expired. Please reconnect.',
+        }));
+        return false;
+      }
+
+      // Sync refreshed token to backend
+      const success = await syncTokensToBackend(credentials);
+
+      if (success) {
+        setState((prev) => ({ ...prev, isConnected: true, error: null }));
+      }
+
+      return success;
+    } catch {
+      setState((prev) => ({
+        ...prev,
+        isConnected: false,
+        error: 'Failed to refresh Tidal token. Please reconnect.',
+      }));
+      return false;
+    }
+  }, [state.isInitialized, syncTokensToBackend]);
+
+  /**
+   * Complete the Tidal OAuth flow after redirect
+   */
+  const finalizeTidalLogin = useCallback(
+    async (callbackUrl: string): Promise<boolean> => {
+      setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+
+      try {
+        // Finalize OAuth with Tidal SDK
+        await finalizeLogin(callbackUrl);
+
+        // Get credentials from SDK
+        const credentials = await credentialsProvider.getCredentials();
+
+        if (!credentials || !credentials.token) {
+          throw new Error('Failed to get credentials from Tidal SDK');
+        }
+
+        // Sync tokens to backend
+        const success = await syncTokensToBackend(credentials);
+
+        if (!success) {
+          throw new Error('Failed to store tokens on server');
+        }
+
+        setState((prev) => ({
+          ...prev,
+          isConnecting: false,
+          isConnected: true,
+          error: null,
+        }));
+
+        return true;
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          isConnecting: false,
+          error: `Failed to complete Tidal login: ${error}`,
+        }));
+        return false;
+      }
+    },
+    [syncTokensToBackend]
+  );
+
+  return {
+    ...state,
+    initiateTidalLogin,
+    finalizeTidalLogin,
+    checkConnection,
+    refreshAndSyncToken,
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ClerkProvider } from '@clerk/clerk-react';
 import { App } from './App';
+
+// Get Clerk publishable key from environment
+const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+if (!CLERK_PUBLISHABLE_KEY) {
+  throw new Error('Missing VITE_CLERK_PUBLISHABLE_KEY environment variable');
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+      <App />
+    </ClerkProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/CallbackPage.tsx
+++ b/frontend/src/pages/CallbackPage.tsx
@@ -1,0 +1,151 @@
+/**
+ * OAuth Callback Page
+ *
+ * Handles the redirect from Tidal OAuth and finalizes the connection.
+ */
+
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { AuthLayout } from '../components/layout/AuthLayout';
+import { useTidalAuth } from '../hooks/useTidalAuth';
+import { RETURN_URL_KEY } from './TidalConnectPage';
+
+type CallbackState = 'processing' | 'success' | 'error' | 'cancelled';
+
+export function CallbackPage(): JSX.Element {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { finalizeTidalLogin, error, isInitialized } = useTidalAuth();
+  const [state, setState] = useState<CallbackState>('processing');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const hasProcessed = useRef(false);
+
+  useEffect(() => {
+    // Wait for Tidal SDK to initialize before processing callback
+    if (!isInitialized) {
+      return;
+    }
+
+    // Prevent multiple processing attempts
+    if (hasProcessed.current) {
+      return;
+    }
+    hasProcessed.current = true;
+
+    async function handleCallback() {
+      // Get just the query string (the SDK parses this with URLSearchParams)
+      const callbackUrl = window.location.search;
+
+      // Check for OAuth error in URL params
+      const params = new URLSearchParams(location.search);
+      if (params.has('error')) {
+        const errorCode = params.get('error');
+        const errorDesc = params.get('error_description');
+
+        // Handle user cancellation specifically
+        if (errorCode === 'access_denied') {
+          setState('cancelled');
+          return;
+        }
+
+        // Other OAuth errors
+        setErrorMessage(errorDesc || errorCode || 'Unknown error');
+        setState('error');
+        return;
+      }
+
+      // Check for authorization code
+      if (!params.has('code')) {
+        setErrorMessage('No authorization code received');
+        setState('error');
+        return;
+      }
+
+      try {
+        const success = await finalizeTidalLogin(callbackUrl);
+
+        if (success) {
+          setState('success');
+          // Get return URL from session storage (set before OAuth redirect)
+          const returnUrl = sessionStorage.getItem(RETURN_URL_KEY) || '/discover';
+          sessionStorage.removeItem(RETURN_URL_KEY);
+
+          // Redirect to original destination after short delay
+          setTimeout(() => {
+            navigate(returnUrl, { replace: true });
+          }, 1500);
+        } else {
+          setState('error');
+          setErrorMessage(error || 'Failed to complete Tidal connection');
+        }
+      } catch (err) {
+        setState('error');
+        setErrorMessage(err instanceof Error ? err.message : 'Unknown error occurred');
+      }
+    }
+
+    handleCallback();
+  }, [finalizeTidalLogin, navigate, location.search, error, isInitialized]);
+
+  const handleRetry = () => {
+    // Preserve return URL for retry
+    navigate('/connect-tidal', { replace: true });
+  };
+
+  return (
+    <AuthLayout>
+      {state === 'processing' && (
+        <div style={{ textAlign: 'center' }}>
+          <div className="auth-loading">
+            <div className="spinner" />
+            <h2>Connecting to Tidal...</h2>
+            <p>Please wait while we complete your connection.</p>
+          </div>
+        </div>
+      )}
+
+      {state === 'success' && (
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>✓</div>
+          <h2>Connected!</h2>
+          <p>Your Tidal account has been connected successfully.</p>
+          <p style={{ opacity: 0.7 }}>Redirecting to AlgoJuke...</p>
+        </div>
+      )}
+
+      {state === 'cancelled' && (
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>←</div>
+          <h2>Connection Cancelled</h2>
+          <p>
+            You cancelled the Tidal authorization. No worries – you can try again
+            whenever you're ready.
+          </p>
+          <p style={{ marginTop: '1rem', opacity: 0.7 }}>
+            AlgoJuke needs access to your Tidal account to provide personalized
+            music recommendations.
+          </p>
+          <button className="auth-button" onClick={handleRetry} style={{ marginTop: '1.5rem' }}>
+            Try Again
+          </button>
+        </div>
+      )}
+
+      {state === 'error' && (
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>✗</div>
+          <h2>Connection Failed</h2>
+          {errorMessage && (
+            <div className="auth-error">
+              <p>{errorMessage}</p>
+            </div>
+          )}
+          <p>There was a problem connecting your Tidal account.</p>
+          <button className="auth-button" onClick={handleRetry}>
+            Try Again
+          </button>
+        </div>
+      )}
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,81 @@
+/**
+ * Landing Page
+ *
+ * Public landing page explaining AlgoJuke service with sign-in option.
+ */
+
+import { SignInButton, useUser } from '@clerk/clerk-react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { AuthLayout } from '../components/layout/AuthLayout';
+
+interface LocationState {
+  from?: { pathname: string };
+}
+
+export function LandingPage(): JSX.Element {
+  const { isSignedIn, isLoaded } = useUser();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Get the original URL the user was trying to access (if any)
+  const state = location.state as LocationState | null;
+  const returnTo = state?.from?.pathname || '/discover';
+
+  // Redirect signed-in users to appropriate page
+  useEffect(() => {
+    if (isLoaded && isSignedIn) {
+      // Let ProtectedRoute handle the routing based on approval/Tidal status
+      navigate(returnTo, { replace: true });
+    }
+  }, [isLoaded, isSignedIn, navigate, returnTo]);
+
+  return (
+    <AuthLayout>
+      <h2>AI-Powered Music Discovery</h2>
+      <p>
+        AlgoJuke uses artificial intelligence to help you discover new music
+        based on your Tidal library. Get personalized recommendations, create
+        smart playlists, and explore music in a whole new way.
+      </p>
+
+      <ul className="auth-features">
+        <li>Semantic search across your library</li>
+        <li>AI-powered music recommendations</li>
+        <li>Smart playlist generation</li>
+        <li>Deep music analysis and insights</li>
+      </ul>
+
+      <SignInButton mode="modal">
+        <button className="auth-button">
+          <GoogleIcon />
+          Sign in with Google
+        </button>
+      </SignInButton>
+
+      <p style={{ marginTop: '1.5rem', fontSize: '0.875rem', opacity: 0.7 }}>
+        AlgoJuke is currently in private beta. Sign in to check if you have access.
+      </p>
+    </AuthLayout>
+  );
+}
+
+/**
+ * Google logo icon
+ */
+function GoogleIcon(): JSX.Element {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+    </svg>
+  );
+}

--- a/frontend/src/pages/TidalConnectPage.tsx
+++ b/frontend/src/pages/TidalConnectPage.tsx
@@ -1,0 +1,64 @@
+/**
+ * Tidal Connect Page
+ *
+ * Prompts approved users to connect their Tidal account.
+ */
+
+import { UserButton } from '@clerk/clerk-react';
+import { useLocation } from 'react-router-dom';
+import { AuthLayout } from '../components/layout/AuthLayout';
+import { TidalConnectButton } from '../components/auth/TidalConnectButton';
+import { useTidalAuth } from '../hooks/useTidalAuth';
+
+interface LocationState {
+  returnTo?: string;
+}
+
+// Storage key for preserving return URL across OAuth redirect
+export const RETURN_URL_KEY = 'algojuke-return-url';
+
+export function TidalConnectPage(): JSX.Element {
+  const { error, isConnecting } = useTidalAuth();
+  const location = useLocation();
+  const state = location.state as LocationState | null;
+  const returnTo = state?.returnTo || '/discover';
+
+  // Store return URL when initiating OAuth (will be read by CallbackPage)
+  const handleConnect = () => {
+    sessionStorage.setItem(RETURN_URL_KEY, returnTo);
+  };
+
+  return (
+    <AuthLayout>
+      <div style={{ position: 'absolute', top: '1rem', right: '1rem' }}>
+        <UserButton afterSignOutUrl="/" />
+      </div>
+      <h2>Connect Your Tidal Account</h2>
+      <p>
+        To use AlgoJuke, you need to connect your Tidal account. This allows us
+        to access your music library and create personalized recommendations.
+      </p>
+
+      <ul className="auth-features">
+        <li>Access your saved albums and playlists</li>
+        <li>Get AI-powered music recommendations</li>
+        <li>Discover new music based on your taste</li>
+        <li>Create smart playlists automatically</li>
+      </ul>
+
+      {error && (
+        <div className="auth-error">
+          <p>{error}</p>
+          <p>Please try again or contact support if the problem persists.</p>
+        </div>
+      )}
+
+      <TidalConnectButton disabled={isConnecting} onBeforeConnect={handleConnect} />
+
+      <p style={{ marginTop: '1.5rem', fontSize: '0.875rem', opacity: 0.7 }}>
+        We only request the permissions needed to provide our service. Your
+        credentials are never stored on our servers.
+      </p>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/WaitlistPage.tsx
+++ b/frontend/src/pages/WaitlistPage.tsx
@@ -1,0 +1,57 @@
+/**
+ * Waitlist Page
+ *
+ * Shown to authenticated users who are not on the approved allowlist.
+ */
+
+import { UserButton } from '@clerk/clerk-react';
+import { AuthLayout } from '../components/layout/AuthLayout';
+
+export function WaitlistPage(): JSX.Element {
+  return (
+    <AuthLayout>
+      <div style={{ textAlign: 'center' }}>
+        <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>👋</div>
+        <h2>Thanks for Your Interest!</h2>
+        <p>
+          AlgoJuke is currently in private beta with limited access. We're
+          working hard to open up to more users soon.
+        </p>
+
+        <div
+          style={{
+            background: 'rgba(255, 255, 255, 0.05)',
+            borderRadius: '12px',
+            padding: '1.5rem',
+            margin: '1.5rem 0',
+          }}
+        >
+          <h3 style={{ color: '#fff', margin: '0 0 0.5rem 0', fontSize: '1rem' }}>
+            You're on the waitlist!
+          </h3>
+          <p style={{ margin: 0, fontSize: '0.875rem' }}>
+            We'll notify you via email when access becomes available.
+          </p>
+        </div>
+
+        <p style={{ marginTop: '1.5rem' }}>
+          In the meantime, make sure you have a Tidal subscription ready – you'll
+          need it to use AlgoJuke when you get access.
+        </p>
+
+        <div
+          style={{
+            marginTop: '2rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '1rem',
+          }}
+        >
+          <span style={{ fontSize: '0.875rem', opacity: 0.7 }}>Signed in as:</span>
+          <UserButton afterSignOutUrl="/" />
+        </div>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/tests/components/auth/CallbackPage.test.tsx
+++ b/frontend/tests/components/auth/CallbackPage.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Component tests for CallbackPage
+ *
+ * Tests the OAuth callback handling page.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { CallbackPage } from '../../../src/pages/CallbackPage';
+import { RETURN_URL_KEY } from '../../../src/pages/TidalConnectPage';
+
+// Mock useNavigate
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Mock useTidalAuth hook
+const mockFinalizeTidalLogin = vi.fn();
+vi.mock('../../../src/hooks/useTidalAuth', () => ({
+  useTidalAuth: () => ({
+    finalizeTidalLogin: mockFinalizeTidalLogin,
+    error: null,
+    isInitialized: true,
+  }),
+}));
+
+// Mock sessionStorage
+const sessionStorageData: Record<string, string> = {};
+const mockSessionStorage = {
+  getItem: (key: string) => sessionStorageData[key] || null,
+  setItem: (key: string, value: string) => { sessionStorageData[key] = value; },
+  removeItem: (key: string) => { delete sessionStorageData[key]; },
+  clear: () => { Object.keys(sessionStorageData).forEach(key => delete sessionStorageData[key]); },
+  length: 0,
+  key: () => null,
+};
+Object.defineProperty(window, 'sessionStorage', { value: mockSessionStorage, writable: true });
+
+// Store original location
+const originalLocation = window.location;
+
+describe('CallbackPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorageData[RETURN_URL_KEY] = '/library';
+  });
+
+  afterEach(() => {
+    mockSessionStorage.clear();
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  const renderWithSearchParams = (search: string) => {
+    // Mock window.location.search since component uses it directly
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search },
+      writable: true,
+    });
+
+    return render(
+      <MemoryRouter initialEntries={[`/auth/tidal/callback${search}`]}>
+        <Routes>
+          <Route path="/auth/tidal/callback" element={<CallbackPage />} />
+          <Route path="/connect-tidal" element={<div>Connect Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+
+  describe('when OAuth succeeds', () => {
+    beforeEach(() => {
+      mockFinalizeTidalLogin.mockResolvedValue(true);
+    });
+
+    it('shows success state after finalization', async () => {
+      renderWithSearchParams('?code=test-auth-code');
+
+      await waitFor(() => {
+        expect(screen.getByText(/connected!/i)).toBeInTheDocument();
+      });
+    });
+
+    it('redirects to stored return URL after success', async () => {
+      vi.useFakeTimers();
+
+      renderWithSearchParams('?code=test-auth-code');
+
+      // Wait for success state (use real promise resolution)
+      await vi.waitFor(() => {
+        expect(screen.getByText(/connected!/i)).toBeInTheDocument();
+      });
+
+      // Advance timer for redirect
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(mockNavigate).toHaveBeenCalledWith('/library', { replace: true });
+
+      vi.useRealTimers();
+    });
+
+    it('redirects to /discover when no return URL stored', async () => {
+      vi.useFakeTimers();
+      delete sessionStorageData[RETURN_URL_KEY];
+
+      renderWithSearchParams('?code=test-auth-code');
+
+      await vi.waitFor(() => {
+        expect(screen.getByText(/connected!/i)).toBeInTheDocument();
+      });
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(mockNavigate).toHaveBeenCalledWith('/discover', { replace: true });
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('when OAuth is cancelled', () => {
+    it('shows cancelled state with user-friendly message', async () => {
+      renderWithSearchParams('?error=access_denied');
+
+      await waitFor(() => {
+        expect(screen.getByText(/connection cancelled/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/you cancelled the tidal authorization/i)).toBeInTheDocument();
+    });
+
+    it('shows try again button', async () => {
+      renderWithSearchParams('?error=access_denied');
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when OAuth fails', () => {
+    it('shows error state with error description', async () => {
+      renderWithSearchParams('?error=server_error&error_description=Internal+server+error');
+
+      await waitFor(() => {
+        expect(screen.getByText(/connection failed/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/internal server error/i)).toBeInTheDocument();
+    });
+
+    it('shows error when no code is present', async () => {
+      renderWithSearchParams('');
+
+      await waitFor(() => {
+        expect(screen.getByText(/no authorization code received/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows error when finalization fails', async () => {
+      mockFinalizeTidalLogin.mockResolvedValue(false);
+
+      renderWithSearchParams('?code=test-auth-code');
+
+      await waitFor(() => {
+        expect(screen.getByText(/connection failed/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/tests/components/auth/LandingPage.test.tsx
+++ b/frontend/tests/components/auth/LandingPage.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Component tests for LandingPage
+ *
+ * Tests the public landing page explaining AlgoJuke service.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { LandingPage } from '../../../src/pages/LandingPage';
+
+// Mock Clerk
+vi.mock('@clerk/clerk-react', () => ({
+  SignInButton: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sign-in-button">{children}</div>
+  ),
+  useUser: () => ({
+    isSignedIn: false,
+    isLoaded: true,
+  }),
+}));
+
+// Mock react-router-dom's useNavigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+describe('LandingPage', () => {
+  const renderLandingPage = () => {
+    return render(
+      <BrowserRouter>
+        <LandingPage />
+      </BrowserRouter>
+    );
+  };
+
+  it('displays AlgoJuke branding', () => {
+    renderLandingPage();
+    expect(screen.getByText('AlgoJuke')).toBeInTheDocument();
+  });
+
+  it('describes AI-powered music discovery', () => {
+    renderLandingPage();
+    expect(screen.getByText(/ai-powered music discovery/i)).toBeInTheDocument();
+  });
+
+  it('mentions private beta status', () => {
+    renderLandingPage();
+    const betaTexts = screen.getAllByText(/private beta/i);
+    expect(betaTexts.length).toBeGreaterThan(0);
+  });
+
+  it('lists key features', () => {
+    renderLandingPage();
+    expect(screen.getByText(/semantic search/i)).toBeInTheDocument();
+    expect(screen.getByText(/ai-powered music recommendations/i)).toBeInTheDocument();
+    expect(screen.getByText(/playlist generation/i)).toBeInTheDocument();
+  });
+
+  it('displays sign in button', () => {
+    renderLandingPage();
+    expect(screen.getByTestId('sign-in-button')).toBeInTheDocument();
+  });
+
+  it('has sign in with google button', () => {
+    renderLandingPage();
+    expect(screen.getByText(/sign in with google/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/tests/components/auth/ProtectedRoute.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Component tests for ProtectedRoute
+ *
+ * Tests the route guard component for various authentication states.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ProtectedRoute } from '../../../src/components/auth/ProtectedRoute';
+
+// Mock Clerk hooks
+const mockUseUser = vi.fn();
+const mockUseAuth = vi.fn();
+vi.mock('@clerk/clerk-react', () => ({
+  useUser: () => mockUseUser(),
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock useTidalAuth hook
+const mockUseTidalAuth = vi.fn();
+vi.mock('../../../src/hooks/useTidalAuth', () => ({
+  useTidalAuth: () => mockUseTidalAuth(),
+}));
+
+// Mock fetch for auth status
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ getToken: () => Promise.resolve('test-token') });
+    mockUseTidalAuth.mockReturnValue({
+      refreshAndSyncToken: vi.fn(),
+      isInitialized: true,
+    });
+  });
+
+  const renderWithRouter = (
+    initialPath: string,
+    requireTidal = false
+  ) => {
+    return render(
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/" element={<div data-testid="landing">Landing</div>} />
+          <Route path="/waitlist" element={<div data-testid="waitlist">Waitlist</div>} />
+          <Route path="/connect-tidal" element={<div data-testid="connect">Connect Tidal</div>} />
+          <Route
+            path="/protected"
+            element={
+              <ProtectedRoute requireTidal={requireTidal}>
+                <div data-testid="protected-content">Protected Content</div>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+
+  describe('when not signed in', () => {
+    beforeEach(() => {
+      mockUseUser.mockReturnValue({ isLoaded: true, isSignedIn: false });
+    });
+
+    it('redirects to landing page', async () => {
+      renderWithRouter('/protected');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('landing')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when signed in but not approved', () => {
+    beforeEach(() => {
+      mockUseUser.mockReturnValue({ isLoaded: true, isSignedIn: true });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          isAuthenticated: true,
+          isApproved: false,
+          hasTidalConnection: false,
+        }),
+      });
+    });
+
+    it('redirects to waitlist page', async () => {
+      renderWithRouter('/protected');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('waitlist')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when approved but no Tidal connection', () => {
+    beforeEach(() => {
+      mockUseUser.mockReturnValue({ isLoaded: true, isSignedIn: true });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          isAuthenticated: true,
+          isApproved: true,
+          hasTidalConnection: false,
+        }),
+      });
+    });
+
+    it('redirects to connect page when requireTidal is true', async () => {
+      renderWithRouter('/protected', true);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('connect')).toBeInTheDocument();
+      });
+    });
+
+    it('renders content when requireTidal is false', async () => {
+      renderWithRouter('/protected', false);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when fully authenticated with Tidal', () => {
+    beforeEach(() => {
+      mockUseUser.mockReturnValue({ isLoaded: true, isSignedIn: true });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          isAuthenticated: true,
+          isApproved: true,
+          hasTidalConnection: true,
+          tidalTokenExpired: false,
+        }),
+      });
+    });
+
+    it('renders protected content', async () => {
+      renderWithRouter('/protected', true);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when loading', () => {
+    beforeEach(() => {
+      mockUseUser.mockReturnValue({ isLoaded: false, isSignedIn: false });
+    });
+
+    it('shows loading state', () => {
+      renderWithRouter('/protected');
+
+      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('when Tidal token is expired', () => {
+    beforeEach(() => {
+      mockUseUser.mockReturnValue({ isLoaded: true, isSignedIn: true });
+    });
+
+    it('attempts to refresh token via SDK', async () => {
+      const mockRefresh = vi.fn().mockResolvedValue(true);
+      mockUseTidalAuth.mockReturnValue({
+        refreshAndSyncToken: mockRefresh,
+        isInitialized: true,
+      });
+
+      // First call returns expired, second call returns refreshed
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+              isAuthenticated: true,
+              isApproved: true,
+              hasTidalConnection: true,
+              tidalTokenExpired: true,
+            }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            isAuthenticated: true,
+            isApproved: true,
+            hasTidalConnection: true,
+            tidalTokenExpired: false,
+          }),
+        });
+      });
+
+      renderWithRouter('/protected', true);
+
+      await waitFor(() => {
+        expect(mockRefresh).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+      });
+    });
+
+    it('redirects to connect page when refresh fails', async () => {
+      const mockRefresh = vi.fn().mockResolvedValue(false);
+      mockUseTidalAuth.mockReturnValue({
+        refreshAndSyncToken: mockRefresh,
+        isInitialized: true,
+      });
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          isAuthenticated: true,
+          isApproved: true,
+          hasTidalConnection: true,
+          tidalTokenExpired: true,
+        }),
+      });
+
+      renderWithRouter('/protected', true);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('connect')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/tests/components/auth/TidalConnectPage.test.tsx
+++ b/frontend/tests/components/auth/TidalConnectPage.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Component tests for TidalConnectPage
+ *
+ * Tests the Tidal connection page for approved users.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TidalConnectPage, RETURN_URL_KEY } from '../../../src/pages/TidalConnectPage';
+
+// Mock Clerk
+vi.mock('@clerk/clerk-react', () => ({
+  UserButton: () => <button data-testid="user-button">User</button>,
+}));
+
+// Mock useTidalAuth hook
+const mockInitiateTidalLogin = vi.fn();
+const mockUseTidalAuth = vi.fn();
+vi.mock('../../../src/hooks/useTidalAuth', () => ({
+  useTidalAuth: () => mockUseTidalAuth(),
+}));
+
+// Mock sessionStorage
+const mockSessionStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  length: 0,
+  key: vi.fn(),
+};
+Object.defineProperty(window, 'sessionStorage', { value: mockSessionStorage });
+
+describe('TidalConnectPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTidalAuth.mockReturnValue({
+      error: null,
+      isConnecting: false,
+      initiateTidalLogin: mockInitiateTidalLogin,
+      isInitialized: true,
+    });
+  });
+
+  const renderWithRouter = (state?: { returnTo?: string }) => {
+    return render(
+      <MemoryRouter initialEntries={[{ pathname: '/connect-tidal', state }]}>
+        <TidalConnectPage />
+      </MemoryRouter>
+    );
+  };
+
+  it('renders the page heading', () => {
+    renderWithRouter();
+    expect(screen.getByRole('heading', { name: /connect your tidal account/i })).toBeInTheDocument();
+  });
+
+  it('displays user button for sign out', () => {
+    renderWithRouter();
+    expect(screen.getByTestId('user-button')).toBeInTheDocument();
+  });
+
+  it('lists features that require Tidal connection', () => {
+    renderWithRouter();
+    expect(screen.getByText(/access your saved albums/i)).toBeInTheDocument();
+    expect(screen.getByText(/ai-powered music recommendations/i)).toBeInTheDocument();
+  });
+
+  it('displays connect button', () => {
+    renderWithRouter();
+    expect(screen.getByText(/connect with tidal/i)).toBeInTheDocument();
+  });
+
+  it('stores return URL in sessionStorage when connecting', () => {
+    renderWithRouter({ returnTo: '/library' });
+
+    const connectButton = screen.getByText(/connect with tidal/i);
+    fireEvent.click(connectButton);
+
+    expect(mockSessionStorage.setItem).toHaveBeenCalledWith(RETURN_URL_KEY, '/library');
+  });
+
+  it('uses /discover as default return URL', () => {
+    renderWithRouter();
+
+    const connectButton = screen.getByText(/connect with tidal/i);
+    fireEvent.click(connectButton);
+
+    expect(mockSessionStorage.setItem).toHaveBeenCalledWith(RETURN_URL_KEY, '/discover');
+  });
+
+  it('displays error message when connection fails', () => {
+    mockUseTidalAuth.mockReturnValue({
+      error: 'Failed to connect to Tidal',
+      isConnecting: false,
+      initiateTidalLogin: mockInitiateTidalLogin,
+      isInitialized: true,
+    });
+
+    renderWithRouter();
+
+    expect(screen.getByText(/failed to connect to tidal/i)).toBeInTheDocument();
+    expect(screen.getByText(/please try again/i)).toBeInTheDocument();
+  });
+
+  it('disables connect button while connecting', () => {
+    mockUseTidalAuth.mockReturnValue({
+      error: null,
+      isConnecting: true,
+      initiateTidalLogin: mockInitiateTidalLogin,
+      isInitialized: true,
+    });
+
+    renderWithRouter();
+
+    expect(screen.getByText(/connecting/i)).toBeInTheDocument();
+  });
+
+  it('mentions privacy and credentials not being stored', () => {
+    renderWithRouter();
+    expect(screen.getByText(/credentials are never stored/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/auth/WaitlistPage.test.tsx
+++ b/frontend/tests/components/auth/WaitlistPage.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Component tests for WaitlistPage
+ *
+ * Tests the waitlist page shown to non-approved users.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { WaitlistPage } from '../../../src/pages/WaitlistPage';
+
+// Mock Clerk
+vi.mock('@clerk/clerk-react', () => ({
+  UserButton: () => <button data-testid="user-button">User</button>,
+}));
+
+describe('WaitlistPage', () => {
+  const renderWaitlistPage = () => {
+    return render(
+      <BrowserRouter>
+        <WaitlistPage />
+      </BrowserRouter>
+    );
+  };
+
+  it('renders thank you message', () => {
+    renderWaitlistPage();
+    expect(screen.getByText(/thanks for your interest/i)).toBeInTheDocument();
+  });
+
+  it('mentions private beta status', () => {
+    renderWaitlistPage();
+    const betaTexts = screen.getAllByText(/private beta/i);
+    expect(betaTexts.length).toBeGreaterThan(0);
+  });
+
+  it('indicates user is on waitlist', () => {
+    renderWaitlistPage();
+    expect(screen.getByText(/on the waitlist/i)).toBeInTheDocument();
+  });
+
+  it('mentions email notification', () => {
+    renderWaitlistPage();
+    expect(screen.getByText(/notify you via email/i)).toBeInTheDocument();
+  });
+
+  it('mentions Tidal subscription requirement', () => {
+    renderWaitlistPage();
+    expect(screen.getByText(/tidal subscription/i)).toBeInTheDocument();
+  });
+
+  it('displays user button for sign out', () => {
+    renderWaitlistPage();
+    expect(screen.getByTestId('user-button')).toBeInTheDocument();
+  });
+
+  it('shows signed in indicator', () => {
+    renderWaitlistPage();
+    expect(screen.getByText(/signed in as/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/hooks/useTidalAuth.test.ts
+++ b/frontend/tests/hooks/useTidalAuth.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Hook tests for useTidalAuth
+ *
+ * Tests the Tidal authentication hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// Mock Clerk useAuth
+const mockGetToken = vi.fn().mockResolvedValue('clerk-token');
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => ({ getToken: mockGetToken }),
+}));
+
+// Mock Tidal SDK
+const mockInit = vi.fn().mockResolvedValue(undefined);
+const mockInitializeLogin = vi.fn().mockResolvedValue('https://tidal.com/oauth/authorize');
+const mockFinalizeLogin = vi.fn().mockResolvedValue(undefined);
+const mockGetCredentials = vi.fn();
+vi.mock('@tidal-music/auth', () => ({
+  init: (...args: unknown[]) => mockInit(...args),
+  initializeLogin: (...args: unknown[]) => mockInitializeLogin(...args),
+  finalizeLogin: (...args: unknown[]) => mockFinalizeLogin(...args),
+  credentialsProvider: {
+    getCredentials: () => mockGetCredentials(),
+  },
+}));
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock window.location
+const originalLocation = window.location;
+beforeEach(() => {
+  Object.defineProperty(window, 'location', {
+    value: { href: '' },
+    writable: true,
+  });
+});
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    value: originalLocation,
+    writable: true,
+  });
+});
+
+// Import hook after mocks are set up
+import { useTidalAuth } from '../../src/hooks/useTidalAuth';
+
+describe('useTidalAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+  });
+
+  describe('initialization', () => {
+    it('initializes SDK on mount', async () => {
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      // Verify SDK was initialized with correct structure
+      // (env vars from .env.example or runtime environment)
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentialsStorageKey: 'algojuke-tidal-auth',
+          scopes: expect.arrayContaining(['user.read', 'collection.read']),
+        })
+      );
+    });
+
+    // Note: Testing missing client ID requires build-time env var handling
+    // which is not practical in unit tests. The behavior is verified manually.
+  });
+
+  describe('initiateTidalLogin', () => {
+    it('redirects to Tidal OAuth URL', async () => {
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      await act(async () => {
+        await result.current.initiateTidalLogin();
+      });
+
+      expect(mockInitializeLogin).toHaveBeenCalled();
+      expect(window.location.href).toBe('https://tidal.com/oauth/authorize');
+    });
+
+    it('sets isConnecting during login', async () => {
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      // Start login (don't await to check intermediate state)
+      act(() => {
+        result.current.initiateTidalLogin();
+      });
+
+      expect(result.current.isConnecting).toBe(true);
+    });
+
+    it('sets error when not initialized', async () => {
+      mockInit.mockImplementationOnce(() => new Promise(() => {})); // Never resolves
+
+      const { result } = renderHook(() => useTidalAuth());
+
+      await act(async () => {
+        await result.current.initiateTidalLogin();
+      });
+
+      expect(result.current.error).toContain('not initialized');
+    });
+  });
+
+  describe('finalizeTidalLogin', () => {
+    beforeEach(() => {
+      mockGetCredentials.mockResolvedValue({
+        token: 'tidal-access-token',
+        expires: Date.now() + 3600000,
+        grantedScopes: ['user.read', 'collection.read'],
+      });
+    });
+
+    it('exchanges code for tokens and stores them', async () => {
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      let success: boolean = false;
+      await act(async () => {
+        success = await result.current.finalizeTidalLogin('?code=auth-code');
+      });
+
+      expect(success).toBe(true);
+      expect(mockFinalizeLogin).toHaveBeenCalledWith('?code=auth-code');
+      expect(mockFetch).toHaveBeenCalledWith('/api/auth/tidal/tokens', expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer clerk-token',
+        }),
+      }));
+    });
+
+    it('sets isConnected on success', async () => {
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      await act(async () => {
+        await result.current.finalizeTidalLogin('?code=auth-code');
+      });
+
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    it('sets error when credentials are missing', async () => {
+      mockGetCredentials.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      let success: boolean = true;
+      await act(async () => {
+        success = await result.current.finalizeTidalLogin('?code=auth-code');
+      });
+
+      expect(success).toBe(false);
+      expect(result.current.error).toContain('Failed to get credentials');
+    });
+
+    it('sets error when backend storage fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ message: 'Storage failed' }),
+      });
+
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      let success: boolean = true;
+      await act(async () => {
+        success = await result.current.finalizeTidalLogin('?code=auth-code');
+      });
+
+      expect(success).toBe(false);
+      expect(result.current.error).toContain('Failed to complete');
+    });
+  });
+
+  describe('refreshAndSyncToken', () => {
+    it('refreshes token via SDK and syncs to backend', async () => {
+      mockGetCredentials.mockResolvedValue({
+        token: 'new-tidal-token',
+        expires: Date.now() + 7200000,
+        grantedScopes: ['user.read', 'collection.read'],
+      });
+
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      let success: boolean = false;
+      await act(async () => {
+        success = await result.current.refreshAndSyncToken();
+      });
+
+      expect(success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith('/api/auth/tidal/tokens', expect.objectContaining({
+        method: 'POST',
+      }));
+    });
+
+    it('returns false when SDK has no credentials', async () => {
+      mockGetCredentials.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      let success: boolean = true;
+      await act(async () => {
+        success = await result.current.refreshAndSyncToken();
+      });
+
+      expect(success).toBe(false);
+      expect(result.current.error).toContain('expired');
+    });
+  });
+
+  describe('checkConnection', () => {
+    it('queries backend for connection status', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ hasTidalConnection: true }),
+      });
+
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      let connected: boolean = false;
+      await act(async () => {
+        connected = await result.current.checkConnection();
+      });
+
+      expect(connected).toBe(true);
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    it('returns false when not connected', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ hasTidalConnection: false }),
+      });
+
+      const { result } = renderHook(() => useTidalAuth());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      let connected: boolean = true;
+      await act(async () => {
+        connected = await result.current.checkConnection();
+      });
+
+      expect(connected).toBe(false);
+    });
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import basicSsl from '@vitejs/plugin-basic-ssl';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), basicSsl()],
   build: {
     target: ['chrome91', 'firefox89', 'safari14', 'edge91'],
     outDir: 'dist',
     sourcemap: true,
   },
   server: {
+    // HTTPS provided by basicSsl plugin (required for Tidal OAuth secure context)
     port: 5173,
     proxy: {
       '/graphql': {

--- a/specs/016-clerk-tidal-auth/checklists/requirements.md
+++ b/specs/016-clerk-tidal-auth/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Clerk Authentication with Tidal Account Connection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The spec correctly uses Clerk and Tidal as product names (not implementation details) since they are explicit user requirements
+- The allowlist approach with hardcoded email is explicitly requested by the user

--- a/specs/016-clerk-tidal-auth/contracts/auth-api.yaml
+++ b/specs/016-clerk-tidal-auth/contracts/auth-api.yaml
@@ -1,0 +1,235 @@
+openapi: 3.1.0
+info:
+  title: AlgoJuke Auth API
+  version: 1.0.0
+  description: Authentication and Tidal connection endpoints for AlgoJuke
+
+servers:
+  - url: http://localhost:4000
+    description: Local development
+
+paths:
+  /api/auth/status:
+    get:
+      summary: Get current user auth status
+      description: Returns the current user's authentication state, approval status, and Tidal connection status
+      operationId: getAuthStatus
+      tags:
+        - Auth
+      security:
+        - clerkAuth: []
+      responses:
+        '200':
+          description: Auth status retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthStatus'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/auth/tidal/tokens:
+    post:
+      summary: Store Tidal OAuth tokens
+      description: Stores Tidal access and refresh tokens in Clerk private metadata
+      operationId: storeTidalTokens
+      tags:
+        - Tidal
+      security:
+        - clerkAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TidalTokensInput'
+      responses:
+        '200':
+          description: Tokens stored successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TidalTokensResponse'
+        '400':
+          description: Invalid token data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: User not on allowlist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    get:
+      summary: Get Tidal token status
+      description: Returns whether Tidal tokens exist and their expiration status (does not return actual tokens)
+      operationId: getTidalTokenStatus
+      tags:
+        - Tidal
+      security:
+        - clerkAuth: []
+      responses:
+        '200':
+          description: Token status retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TidalTokenStatus'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/auth/tidal/refresh:
+    post:
+      summary: Refresh Tidal access token
+      description: Refreshes the Tidal access token using the stored refresh token
+      operationId: refreshTidalToken
+      tags:
+        - Tidal
+      security:
+        - clerkAuth: []
+      responses:
+        '200':
+          description: Token refreshed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TidalTokenStatus'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: User not on allowlist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: No Tidal connection or refresh failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  securitySchemes:
+    clerkAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Clerk session JWT
+
+  schemas:
+    AuthStatus:
+      type: object
+      required:
+        - isAuthenticated
+        - isApproved
+        - hasTidalConnection
+      properties:
+        isAuthenticated:
+          type: boolean
+          description: Whether user is signed in via Clerk
+        isApproved:
+          type: boolean
+          description: Whether user's email is on the allowlist
+        hasTidalConnection:
+          type: boolean
+          description: Whether user has connected their Tidal account
+        email:
+          type: string
+          format: email
+          description: User's primary email address
+        userId:
+          type: string
+          description: Clerk user ID
+
+    TidalTokensInput:
+      type: object
+      required:
+        - accessToken
+        - refreshToken
+        - expiresAt
+        - scopes
+      properties:
+        accessToken:
+          type: string
+          minLength: 1
+          description: Tidal OAuth access token
+        refreshToken:
+          type: string
+          minLength: 1
+          description: Tidal OAuth refresh token
+        expiresAt:
+          type: integer
+          description: Token expiration timestamp (Unix ms)
+        scopes:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: Granted OAuth scopes
+
+    TidalTokensResponse:
+      type: object
+      required:
+        - success
+        - connectedAt
+      properties:
+        success:
+          type: boolean
+        connectedAt:
+          type: integer
+          description: Connection timestamp (Unix ms)
+
+    TidalTokenStatus:
+      type: object
+      required:
+        - hasTokens
+      properties:
+        hasTokens:
+          type: boolean
+          description: Whether Tidal tokens exist
+        expiresAt:
+          type: integer
+          description: Token expiration timestamp (Unix ms)
+        isExpired:
+          type: boolean
+          description: Whether the access token has expired
+        scopes:
+          type: array
+          items:
+            type: string
+          description: Granted OAuth scopes
+
+    Error:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          description: Error code
+        message:
+          type: string
+          description: Human-readable error message

--- a/specs/016-clerk-tidal-auth/contracts/schemas.ts
+++ b/specs/016-clerk-tidal-auth/contracts/schemas.ts
@@ -1,0 +1,123 @@
+/**
+ * Auth API Schemas
+ * Generated for feature 016-clerk-tidal-auth
+ *
+ * These Zod schemas define the contract between frontend and backend
+ * for authentication and Tidal connection endpoints.
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Request Schemas
+// ============================================================================
+
+/**
+ * Schema for storing Tidal OAuth tokens
+ * POST /api/auth/tidal/tokens
+ */
+export const TidalTokensInputSchema = z.object({
+  accessToken: z.string().min(1, 'Access token is required'),
+  refreshToken: z.string().min(1, 'Refresh token is required'),
+  expiresAt: z.number().positive('Expiration must be a positive timestamp'),
+  scopes: z.array(z.string()).min(1, 'At least one scope is required'),
+});
+
+export type TidalTokensInput = z.infer<typeof TidalTokensInputSchema>;
+
+// ============================================================================
+// Response Schemas
+// ============================================================================
+
+/**
+ * Schema for auth status response
+ * GET /api/auth/status
+ */
+export const AuthStatusSchema = z.object({
+  isAuthenticated: z.boolean(),
+  isApproved: z.boolean(),
+  hasTidalConnection: z.boolean(),
+  email: z.string().email().optional(),
+  userId: z.string().optional(),
+});
+
+export type AuthStatus = z.infer<typeof AuthStatusSchema>;
+
+/**
+ * Schema for Tidal tokens storage response
+ * POST /api/auth/tidal/tokens
+ */
+export const TidalTokensResponseSchema = z.object({
+  success: z.boolean(),
+  connectedAt: z.number().positive(),
+});
+
+export type TidalTokensResponse = z.infer<typeof TidalTokensResponseSchema>;
+
+/**
+ * Schema for Tidal token status response
+ * GET /api/auth/tidal/tokens
+ */
+export const TidalTokenStatusSchema = z.object({
+  hasTokens: z.boolean(),
+  expiresAt: z.number().optional(),
+  isExpired: z.boolean().optional(),
+  scopes: z.array(z.string()).optional(),
+});
+
+export type TidalTokenStatus = z.infer<typeof TidalTokenStatusSchema>;
+
+/**
+ * Schema for error responses
+ */
+export const ErrorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+});
+
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
+// ============================================================================
+// Internal Schemas (Backend Only)
+// ============================================================================
+
+/**
+ * Schema for Tidal tokens stored in Clerk private metadata
+ * This is the complete token object including connectedAt
+ */
+export const TidalTokensSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  expiresAt: z.number().positive(),
+  scopes: z.array(z.string()).min(1),
+  connectedAt: z.number().positive(),
+});
+
+export type TidalTokens = z.infer<typeof TidalTokensSchema>;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Required Tidal OAuth scopes
+ */
+export const REQUIRED_TIDAL_SCOPES = [
+  'collection.read',
+  'playlists.read',
+  'playlists.write',
+  'recommendations.read',
+  'search.read',
+  'user.read',
+] as const;
+
+export type TidalScope = (typeof REQUIRED_TIDAL_SCOPES)[number];
+
+/**
+ * Validate that all required scopes are present
+ */
+export function hasRequiredScopes(scopes: string[]): boolean {
+  return REQUIRED_TIDAL_SCOPES.every((required) =>
+    scopes.includes(required)
+  );
+}

--- a/specs/016-clerk-tidal-auth/data-model.md
+++ b/specs/016-clerk-tidal-auth/data-model.md
@@ -1,0 +1,213 @@
+# Data Model: Clerk Authentication with Tidal Account Connection
+
+**Date**: 2026-01-03
+**Feature**: 016-clerk-tidal-auth
+
+## Overview
+
+This feature does not introduce new database entities. User identity is managed by Clerk, and Tidal connection data is stored in Clerk's private metadata. The allowlist is a static configuration file.
+
+## Entities
+
+### User (Clerk-Managed)
+
+User identity is fully managed by Clerk. We access user data via Clerk's API.
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| `id` | string | Clerk | Unique user identifier (e.g., `user_xxx`) |
+| `emailAddresses` | EmailAddress[] | Clerk | User's email addresses |
+| `primaryEmailAddress` | EmailAddress | Clerk | Primary email for identification |
+| `privateMetadata` | object | Clerk | Backend-only metadata (stores Tidal tokens) |
+| `publicMetadata` | object | Clerk | Frontend-readable metadata |
+
+**Access Pattern**:
+```typescript
+// Backend access
+import { clerkClient, getAuth } from '@clerk/express';
+
+const { userId } = getAuth(req);
+const user = await clerkClient.users.getUser(userId);
+const email = user.primaryEmailAddress?.emailAddress;
+```
+
+---
+
+### TidalTokens (Clerk Private Metadata)
+
+Stored in `user.privateMetadata.tidal`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `accessToken` | string | Tidal OAuth access token |
+| `refreshToken` | string | Tidal OAuth refresh token |
+| `expiresAt` | number | Token expiration (Unix timestamp ms) |
+| `scopes` | string[] | Granted OAuth scopes |
+| `connectedAt` | number | Connection timestamp (Unix ms) |
+
+**Validation Rules**:
+- `accessToken`: Required, non-empty string
+- `refreshToken`: Required, non-empty string
+- `expiresAt`: Required, positive number, must be in the future when stored
+- `scopes`: Required, non-empty array of strings
+- `connectedAt`: Required, positive number
+
+**TypeScript Schema**:
+```typescript
+import { z } from 'zod';
+
+export const TidalTokensSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  expiresAt: z.number().positive(),
+  scopes: z.array(z.string()).min(1),
+  connectedAt: z.number().positive(),
+});
+
+export type TidalTokens = z.infer<typeof TidalTokensSchema>;
+```
+
+**Storage Pattern**:
+```typescript
+// Store tokens
+await clerkClient.users.updateUserMetadata(userId, {
+  privateMetadata: {
+    tidal: {
+      accessToken: '...',
+      refreshToken: '...',
+      expiresAt: Date.now() + 86400000,
+      scopes: ['collection.read', 'playlists.read', ...],
+      connectedAt: Date.now(),
+    },
+  },
+});
+
+// Retrieve tokens
+const user = await clerkClient.users.getUser(userId);
+const tidalTokens = user.privateMetadata?.tidal as TidalTokens | undefined;
+```
+
+---
+
+### Allowlist (Static Configuration)
+
+Hardcoded in `backend/src/config/allowlist.ts`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `APPROVED_EMAILS` | readonly string[] | List of approved Google email addresses |
+
+**Validation Rules**:
+- Emails must be lowercase
+- Emails must be valid email format
+- At least one email must exist
+
+**Implementation**:
+```typescript
+// backend/src/config/allowlist.ts
+export const APPROVED_EMAILS = [
+  'anton.tcholakov@gmail.com',
+] as const;
+
+export type ApprovedEmail = typeof APPROVED_EMAILS[number];
+
+export function isApprovedUser(email: string): boolean {
+  return APPROVED_EMAILS.includes(
+    email.toLowerCase() as ApprovedEmail
+  );
+}
+```
+
+---
+
+## State Transitions
+
+### User Auth State
+
+```
+┌─────────────┐
+│ Unauthenticated │
+└──────┬──────┘
+       │ Sign in with Google
+       ▼
+┌─────────────┐     Not on allowlist    ┌──────────┐
+│ Authenticated │ ─────────────────────▶ │ Waitlist │
+└──────┬──────┘                         └──────────┘
+       │ On allowlist
+       ▼
+┌─────────────┐
+│ Approved    │ (no Tidal connection)
+└──────┬──────┘
+       │ Complete Tidal OAuth
+       ▼
+┌─────────────┐
+│ Connected   │ (full access)
+└─────────────┘
+```
+
+### State Checks
+
+| State | isSignedIn | isApproved | hasTidal | Access Level |
+|-------|------------|------------|----------|--------------|
+| Unauthenticated | ❌ | - | - | Landing page only |
+| Authenticated (not approved) | ✅ | ❌ | - | Waitlist page |
+| Approved (no Tidal) | ✅ | ✅ | ❌ | Tidal connect page |
+| Connected | ✅ | ✅ | ✅ | Full application |
+| Token Refresh Failed | ✅ | ✅ | ❌* | Tidal connect page (with error) |
+
+*Note: When token refresh fails, `hasTidal` becomes `false` (tokens are invalidated). User is redirected to Tidal connect page with an error message explaining they need to reconnect.
+
+---
+
+## Relationships
+
+```
+┌─────────────────────────────────────────────────┐
+│                   Clerk                          │
+│  ┌───────────────────────────────────────────┐  │
+│  │               User                         │  │
+│  │  - id                                      │  │
+│  │  - primaryEmailAddress                     │  │
+│  │  - privateMetadata ─────┐                  │  │
+│  └─────────────────────────┼─────────────────┘  │
+│                            │                     │
+│                            ▼                     │
+│  ┌───────────────────────────────────────────┐  │
+│  │         TidalTokens (embedded)             │  │
+│  │  - accessToken                             │  │
+│  │  - refreshToken                            │  │
+│  │  - expiresAt                               │  │
+│  │  - scopes                                  │  │
+│  │  - connectedAt                             │  │
+│  └───────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────┐
+│              Static Config                       │
+│  ┌───────────────────────────────────────────┐  │
+│  │             Allowlist                      │  │
+│  │  - APPROVED_EMAILS[]                       │  │
+│  │  - isApprovedUser(email)                   │  │
+│  └───────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────┘
+```
+
+---
+
+## Data Constraints
+
+| Constraint | Value | Rationale |
+|------------|-------|-----------|
+| Clerk private metadata size | 8KB max | Clerk platform limit |
+| Typical token payload | ~1KB | Well within limit |
+| Tidal access token TTL | 24 hours | Per Tidal OAuth spec |
+| Tidal refresh token TTL | Variable | Depends on user activity |
+
+---
+
+## No Database Migrations Required
+
+This feature does not require any PostgreSQL schema changes. All auth data is managed externally:
+- User identity → Clerk
+- Tidal tokens → Clerk private metadata
+- Allowlist → Static TypeScript configuration

--- a/specs/016-clerk-tidal-auth/plan.md
+++ b/specs/016-clerk-tidal-auth/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Clerk Authentication with Tidal Account Connection
+
+**Branch**: `016-clerk-tidal-auth` | **Date**: 2026-01-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/016-clerk-tidal-auth/spec.md`
+
+## Summary
+
+Implement user authentication via Clerk with Google OAuth, plus Tidal account connection using the Tidal SDK authorization code flow. The landing page is public; approved users (from a hardcoded allowlist) can connect their Tidal account, while non-approved users see a waitlist page. Tidal tokens are stored in Clerk's private metadata.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3.3 / Node.js 20.x (backend), TypeScript 5.3.3 / React 18.2.0 (frontend)
+**Primary Dependencies**:
+- Backend: `@clerk/express`, `@clerk/backend`, existing Express/Apollo Server
+- Frontend: `@clerk/clerk-react`, `@tidal-music/auth`, existing React/Vite stack
+**Storage**: Clerk private metadata (Tidal tokens), existing PostgreSQL (no schema changes needed for auth)
+**Testing**: Vitest (existing), React Testing Library (existing)
+**Target Platform**: Web application (browser-based)
+**Project Type**: Web (frontend + backend)
+**Performance Goals**: SC-001 (60s flow completion), SC-003 (3s return user access)
+**Constraints**: HTTPS required for Tidal OAuth, max 8KB Clerk private metadata
+**Scale/Scope**: Single approved user initially (anton.tcholakov@gmail.com), designed for future allowlist expansion
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Test-First Development | ✅ PASS | Contract tests for auth endpoints, integration tests for OAuth flows |
+| II. Code Quality Standards | ✅ PASS | Minimal complexity - standard OAuth patterns, no custom abstractions |
+| III. User Experience Consistency | ✅ PASS | Clear user flows defined in spec with acceptance scenarios |
+| IV. Robust Architecture | ✅ PASS | Error handling for OAuth failures, token refresh edge cases documented |
+| V. Security by Design | ✅ PASS | Clerk handles auth, tokens in private metadata, allowlist enforcement |
+
+**Gate Result**: PASS - Proceed to Phase 0
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-clerk-tidal-auth/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── src/
+│   ├── config/
+│   │   └── allowlist.ts           # Hardcoded approved emails
+│   ├── middleware/
+│   │   └── clerkAuth.ts           # Clerk middleware + auth helpers
+│   ├── routes/
+│   │   └── auth.ts                # Tidal OAuth callback routes
+│   ├── services/
+│   │   └── tidalAuthService.ts    # Tidal token management
+│   └── server.ts                  # Add Clerk middleware
+└── tests/
+    ├── contract/
+    │   └── auth/                  # Auth endpoint contracts
+    └── integration/
+        └── auth/                  # OAuth flow integration tests
+
+frontend/
+├── src/
+│   ├── components/
+│   │   ├── auth/
+│   │   │   ├── ProtectedRoute.tsx      # Route guard component
+│   │   │   └── TidalConnectButton.tsx  # Tidal OAuth trigger
+│   │   └── layout/
+│   │       └── AuthLayout.tsx          # Layout for auth pages
+│   ├── pages/
+│   │   ├── LandingPage.tsx             # Public landing page
+│   │   ├── TidalConnectPage.tsx        # Tidal connection prompt
+│   │   ├── WaitlistPage.tsx            # Non-approved user page
+│   │   └── CallbackPage.tsx            # OAuth callback handler
+│   ├── hooks/
+│   │   └── useTidalAuth.ts             # Tidal auth state hook
+│   └── App.tsx                         # Add ClerkProvider + routes
+└── tests/
+    └── components/
+        └── auth/                       # Component tests
+```
+
+**Structure Decision**: Extends existing web application structure. Auth components added to frontend, auth services added to backend. No new top-level directories required.
+
+## Complexity Tracking
+
+> No Constitution Check violations requiring justification.
+
+| Decision | Rationale | Alternative Considered |
+|----------|-----------|------------------------|
+| Tidal SDK in frontend | SDK designed for browser (handles PKCE, redirects) | Backend-only OAuth rejected - SDK requires browser context |
+| Tokens in Clerk metadata | Centralizes auth concerns, encrypted at rest | PostgreSQL rejected - adds schema, duplicates auth storage |
+| Hardcoded allowlist file | Simplest for single-user beta | Env var rejected - harder to extend to multiple emails |
+
+## Constitution Check (Post-Design)
+
+*Re-evaluated after Phase 1 design completion.*
+
+| Principle | Status | Design Evidence |
+|-----------|--------|-----------------|
+| I. Test-First Development | ✅ PASS | Contract schemas in `contracts/schemas.ts`, test directories defined in project structure |
+| II. Code Quality Standards | ✅ PASS | Zod validation for all inputs, clear separation of concerns, no unnecessary abstractions |
+| III. User Experience Consistency | ✅ PASS | Four distinct user states with clear transitions in data-model.md |
+| IV. Robust Architecture | ✅ PASS | Error handling defined in OpenAPI spec, token refresh flow documented |
+| V. Security by Design | ✅ PASS | Tokens in private metadata (backend-only), allowlist enforcement, Clerk handles sessions |
+
+**Post-Design Gate Result**: PASS - Ready for task generation (`/speckit.tasks`)

--- a/specs/016-clerk-tidal-auth/quickstart.md
+++ b/specs/016-clerk-tidal-auth/quickstart.md
@@ -1,0 +1,187 @@
+# Quickstart: Clerk Authentication with Tidal Account Connection
+
+**Feature**: 016-clerk-tidal-auth
+**Date**: 2026-01-03
+
+## Prerequisites
+
+1. **Clerk Account**: Sign up at [clerk.com](https://clerk.com) and create an application
+2. **Tidal Developer Account**: Register at [developer.tidal.com](https://developer.tidal.com) and create an app
+3. **HTTPS for Development**: Required for Tidal OAuth (use Vite's HTTPS mode)
+
+## Environment Setup
+
+### 1. Backend Environment Variables
+
+Create/update `backend/.env`:
+
+```bash
+# Clerk Authentication
+CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+
+# Tidal OAuth (existing, but ensure these are set)
+TIDAL_CLIENT_ID=your_tidal_client_id
+TIDAL_CLIENT_SECRET=your_tidal_client_secret  # If required by Tidal
+```
+
+### 2. Frontend Environment Variables
+
+Create/update `frontend/.env`:
+
+```bash
+# Clerk Authentication
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_...
+
+# Tidal OAuth
+VITE_TIDAL_CLIENT_ID=your_tidal_client_id
+VITE_TIDAL_REDIRECT_URI=https://localhost:5173/auth/tidal/callback
+```
+
+### 3. Clerk Dashboard Configuration
+
+1. Go to your Clerk Dashboard → **Configure** → **Social connections**
+2. Enable **Google** OAuth provider
+3. Under **Paths**, ensure sign-in and sign-up URLs are configured
+
+### 4. Tidal Developer Portal Configuration
+
+1. Go to your Tidal app settings
+2. Add redirect URI: `https://localhost:5173/auth/tidal/callback`
+3. Note your Client ID for the frontend
+
+## Installation
+
+### Backend Dependencies
+
+```bash
+cd backend
+npm install @clerk/express @clerk/backend
+```
+
+### Frontend Dependencies
+
+```bash
+cd frontend
+npm install @clerk/clerk-react @tidal-music/auth
+```
+
+## Quick Verification
+
+### 1. Start Backend
+
+```bash
+cd backend
+npm run dev
+```
+
+### 2. Start Frontend with HTTPS
+
+Update `frontend/vite.config.ts` for HTTPS:
+
+```typescript
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    https: true,  // Enable HTTPS for Tidal OAuth
+    port: 5173,
+  },
+});
+```
+
+Then:
+
+```bash
+cd frontend
+npm run dev
+```
+
+### 3. Test Auth Flow
+
+1. Open `https://localhost:5173`
+2. You should see the landing page
+3. Click "Sign in with Google"
+4. Sign in with `anton.tcholakov@gmail.com` (approved user)
+5. You should be prompted to connect Tidal
+6. Complete Tidal OAuth
+7. You should reach the main application
+
+### 4. Test Non-Approved User
+
+1. Sign out
+2. Sign in with a different Google account
+3. You should see the waitlist page
+
+## Key Files to Create
+
+### Backend
+
+| File | Purpose |
+|------|---------|
+| `src/config/allowlist.ts` | Approved email addresses |
+| `src/middleware/clerkAuth.ts` | Clerk middleware setup |
+| `src/routes/auth.ts` | Auth API endpoints |
+| `src/services/tidalAuthService.ts` | Tidal token management |
+
+### Frontend
+
+| File | Purpose |
+|------|---------|
+| `src/components/auth/ProtectedRoute.tsx` | Route protection |
+| `src/components/auth/TidalConnectButton.tsx` | Tidal OAuth trigger |
+| `src/pages/LandingPage.tsx` | Public landing page |
+| `src/pages/TidalConnectPage.tsx` | Tidal connection prompt |
+| `src/pages/WaitlistPage.tsx` | Non-approved user page |
+| `src/pages/CallbackPage.tsx` | OAuth callback handler |
+| `src/hooks/useTidalAuth.ts` | Tidal auth state hook |
+
+## Testing
+
+### Run Backend Tests
+
+```bash
+cd backend
+npm test -- --grep "auth"
+```
+
+### Run Frontend Tests
+
+```bash
+cd frontend
+npm test -- --grep "auth"
+```
+
+## Troubleshooting
+
+### "Insecure context" Error from Tidal SDK
+
+- Ensure you're using HTTPS (`https://localhost:5173`)
+- Check that `vite.config.ts` has `https: true`
+
+### "Invalid redirect URI" from Tidal
+
+- Verify the redirect URI in Tidal Developer Portal matches exactly
+- Include the full path: `https://localhost:5173/auth/tidal/callback`
+
+### Clerk Middleware Not Working
+
+- Ensure `CLERK_SECRET_KEY` is set in backend `.env`
+- Check that `clerkMiddleware()` is applied before routes
+
+### User Not Recognized as Approved
+
+- Check email case sensitivity (allowlist uses lowercase)
+- Verify the exact email in `backend/src/config/allowlist.ts`
+
+## Next Steps
+
+After completing the quickstart:
+
+1. Run `/speckit.tasks` to generate implementation tasks
+2. Implement tests first (per constitution)
+3. Implement backend auth middleware
+4. Implement frontend auth flow
+5. Validate against acceptance scenarios in spec.md

--- a/specs/016-clerk-tidal-auth/research.md
+++ b/specs/016-clerk-tidal-auth/research.md
@@ -1,0 +1,229 @@
+# Research: Clerk Authentication with Tidal Account Connection
+
+**Date**: 2026-01-03
+**Feature**: 016-clerk-tidal-auth
+
+## Research Questions
+
+### 1. Clerk Integration Pattern
+
+**Question**: How to integrate Clerk with the existing Express/Apollo backend and React frontend?
+
+**Decision**: Use `@clerk/express` for backend middleware and `@clerk/clerk-react` for frontend components.
+
+**Rationale**:
+- Clerk officially supports Express.js with dedicated SDK (`@clerk/express`)
+- `clerkMiddleware()` attaches auth state to requests automatically
+- `requireAuth()` middleware protects routes with automatic redirect
+- `@clerk/clerk-react` provides `<ClerkProvider>`, `<SignedIn>`, `<SignedOut>`, `<SignInButton>`, `<UserButton>` components
+- Backend can access user data via `clerkClient.users.getUser(userId)`
+
+**Alternatives Considered**:
+- `@clerk/clerk-sdk-node` (deprecated, EOL January 2025)
+- Custom JWT validation (unnecessary complexity, loses Clerk features)
+
+**Sources**:
+- [Clerk Express Quickstart](https://clerk.com/docs/quickstarts/express)
+- [Clerk React Quickstart](https://clerk.com/docs/quickstarts/react)
+
+---
+
+### 2. Tidal SDK Authorization Code Flow
+
+**Question**: How to implement Tidal OAuth in the browser using their SDK?
+
+**Decision**: Use `@tidal-music/auth` package with authorization code flow in the frontend.
+
+**Rationale**:
+- SDK handles PKCE automatically (required by Tidal/OAuth 2.1)
+- Three-step flow: `init()` → `initializeLogin()` → `finalizeLogin()`
+- SDK manages token refresh internally via `credentialsProvider.getCredentials()`
+- Requires HTTPS (secure context) for OAuth redirects
+- Browser-based SDK cannot run on backend (requires browser context)
+
+**Implementation Pattern**:
+```typescript
+import { init, initializeLogin, finalizeLogin, credentialsProvider } from '@tidal-music/auth';
+
+// 1. Initialize SDK
+init({
+  clientId: TIDAL_CLIENT_ID,
+  credentialsStorageKey: 'tidal-auth'
+});
+
+// 2. Start login (returns URL to open)
+const loginUrl = await initializeLogin({ redirectUri: CALLBACK_URL });
+window.location.href = loginUrl;
+
+// 3. After redirect, finalize (in callback page)
+await finalizeLogin(window.location.href);
+
+// 4. Get credentials (call each time, SDK handles refresh)
+const credentials = await credentialsProvider.getCredentials();
+```
+
+**Alternatives Considered**:
+- Backend OAuth implementation (rejected - SDK designed for browser)
+- Manual PKCE implementation (rejected - SDK handles this)
+
+**Sources**:
+- [Tidal Auth SDK Documentation](https://tidal-music.github.io/tidal-sdk-web/modules/_tidal-music_auth.html)
+- [Tidal Developer Portal - Authorization](https://developer.tidal.com/documentation/api-sdk/api-sdk-authorization)
+
+---
+
+### 3. Token Storage Strategy
+
+**Question**: Where to store Tidal access/refresh tokens?
+
+**Decision**: Store in Clerk's private metadata via backend API.
+
+**Rationale**:
+- Private metadata is backend-only (never exposed to frontend)
+- Encrypted at rest by Clerk
+- 8KB limit sufficient for OAuth tokens (~1KB typically)
+- Centralized with user identity (no separate database table)
+- Access via `clerkClient.users.updateUserMetadata()` and `user.privateMetadata`
+
+**Token Structure**:
+```typescript
+interface TidalTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;  // Unix timestamp
+  scopes: string[];
+}
+```
+
+**Flow**:
+1. Frontend completes Tidal OAuth, gets tokens from SDK
+2. Frontend sends tokens to backend endpoint
+3. Backend stores in Clerk private metadata
+4. Backend retrieves tokens when making Tidal API calls
+
+**Alternatives Considered**:
+- PostgreSQL table (rejected - duplicates auth storage, adds schema)
+- Clerk session token claims (rejected - 1.2KB limit, exposed in JWT)
+- Frontend localStorage (rejected - security risk, not accessible by backend)
+
+**Sources**:
+- [Clerk User Metadata](https://clerk.com/docs/users/metadata)
+
+---
+
+### 4. Allowlist Enforcement
+
+**Question**: How to implement the approved user allowlist?
+
+**Decision**: Hardcoded TypeScript array in `backend/src/config/allowlist.ts`.
+
+**Rationale**:
+- Simplest approach for single-user beta
+- Type-safe, easy to extend
+- No environment variable parsing complexity
+- Clear audit trail in version control
+- Backend-only check (cannot be bypassed)
+
+**Implementation**:
+```typescript
+// backend/src/config/allowlist.ts
+export const APPROVED_EMAILS = [
+  'anton.tcholakov@gmail.com',
+] as const;
+
+export function isApprovedUser(email: string): boolean {
+  return APPROVED_EMAILS.includes(email.toLowerCase() as typeof APPROVED_EMAILS[number]);
+}
+```
+
+**Enforcement Points**:
+1. After Google sign-in: Check email against allowlist
+2. Before Tidal connection: Verify approved status
+3. On protected routes: Verify approved + Tidal connected
+
+**Alternatives Considered**:
+- Environment variable (rejected - harder for multiple emails)
+- Database table (rejected - overkill for beta)
+- Clerk user roles/permissions (rejected - requires Clerk Organizations)
+
+---
+
+### 5. Route Protection Strategy
+
+**Question**: How to protect routes based on auth state?
+
+**Decision**: Three-tier protection with React Router and backend middleware.
+
+**Tiers**:
+1. **Public**: Landing page (unauthenticated access)
+2. **Authenticated + Approved**: Tidal connection page
+3. **Fully Connected**: Main application
+
+**Frontend Protection**:
+```typescript
+// ProtectedRoute.tsx
+function ProtectedRoute({ requireTidal, children }) {
+  const { isSignedIn, user } = useUser();
+  const { hasTidalConnection } = useTidalAuth();
+
+  if (!isSignedIn) return <Navigate to="/" />;
+  if (!isApproved(user.email)) return <Navigate to="/waitlist" />;
+  if (requireTidal && !hasTidalConnection) return <Navigate to="/connect-tidal" />;
+  return children;
+}
+```
+
+**Backend Protection**:
+- `requireAuth()` middleware on all API routes
+- Custom middleware to verify allowlist status
+- Tidal token endpoints require approved user
+
+---
+
+### 6. OAuth Callback Handling
+
+**Question**: How to handle the Tidal OAuth callback?
+
+**Decision**: Dedicated callback page that finalizes OAuth and stores tokens.
+
+**Flow**:
+1. Tidal redirects to `/auth/tidal/callback?code=...`
+2. CallbackPage calls `finalizeLogin(url)`
+3. Gets credentials via `credentialsProvider.getCredentials()`
+4. Sends tokens to backend via authenticated POST
+5. Backend stores in Clerk private metadata
+6. Redirects to main application
+
+**Error Handling**:
+- OAuth cancelled: Show message, offer retry
+- OAuth failed: Show error, offer retry
+- Backend storage failed: Show error, tokens remain in SDK
+
+---
+
+## Dependencies
+
+### New Packages
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@clerk/express` | ^3.x | Backend Clerk middleware |
+| `@clerk/backend` | ^1.x | Backend Clerk client |
+| `@clerk/clerk-react` | ^5.x | Frontend Clerk components |
+| `@tidal-music/auth` | ^1.4.0 | Tidal OAuth SDK |
+
+### Environment Variables
+
+| Variable | Location | Description |
+|----------|----------|-------------|
+| `CLERK_PUBLISHABLE_KEY` | Frontend (.env) | Clerk public key |
+| `CLERK_SECRET_KEY` | Backend (.env) | Clerk secret key |
+| `TIDAL_CLIENT_ID` | Both (.env) | Tidal OAuth client ID |
+| `TIDAL_CLIENT_SECRET` | Backend only (.env) | Tidal OAuth client secret (if required) |
+| `VITE_TIDAL_REDIRECT_URI` | Frontend (.env) | OAuth callback URL |
+
+---
+
+## Open Questions Resolved
+
+All technical questions have been answered. No outstanding NEEDS CLARIFICATION items.

--- a/specs/016-clerk-tidal-auth/spec.md
+++ b/specs/016-clerk-tidal-auth/spec.md
@@ -1,0 +1,138 @@
+# Feature Specification: Clerk Authentication with Tidal Account Connection
+
+**Feature Branch**: `016-clerk-tidal-auth`
+**Created**: 2026-01-03
+**Status**: Draft
+**Input**: User description: "User login with Google account via Clerk and ability to connect their Tidal account as a social connection with Tidal connection tokens stored in Clerk's private metadata. User signin flow that requires users to sign in with Google and then connect their Tidal account. Users must connect their Tidal account to use the application. A simple landing page explaining that AlgoJuke is an AI-powered music discovery service currently in private beta. Access is restricted to a hardcoded list of Google accounts which currently only includes anton.tcholakov@gmail.com. If another user signs in, don't allow them to connect their Tidal account and simply show them a page thanking them for their interest and notifying them that AlgoJuke is in private beta and they will be notified when access is more widely available."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Approved User Signs In and Connects Tidal (Priority: P1)
+
+An approved user (on the allowlist) visits AlgoJuke for the first time. They see the landing page explaining the service, click "Sign in with Google," authenticate with their Google account, and are then prompted to connect their Tidal account. After completing the Tidal OAuth flow, they gain full access to the application.
+
+**Why this priority**: This is the core happy path that enables the primary use case. Without this flow working, no user can access the application's music discovery features.
+
+**Independent Test**: Can be fully tested by signing in with an allowlisted Google account, completing Tidal connection, and verifying access to the main application.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with email "anton.tcholakov@gmail.com" visits the landing page, **When** they click "Sign in with Google" and authenticate, **Then** they are shown the Tidal connection screen.
+2. **Given** an approved user has authenticated with Google, **When** they complete the Tidal OAuth flow, **Then** their Tidal tokens are stored and they are redirected to the main application.
+3. **Given** an approved user has connected their Tidal account, **When** they return to the application later, **Then** they are automatically signed in and have full access without re-connecting Tidal.
+
+---
+
+### User Story 2 - Non-Approved User Experience (Priority: P2)
+
+A user not on the allowlist visits AlgoJuke, sees the landing page, and signs in with Google. Instead of being shown the Tidal connection flow, they see a waitlist page thanking them for their interest and informing them that the service is in private beta.
+
+**Why this priority**: Essential for gracefully handling unauthorized users and preventing access to beta-only features while maintaining a positive brand impression.
+
+**Independent Test**: Can be tested by signing in with any Google account not on the allowlist and verifying the waitlist page appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with email "randomuser@gmail.com" (not on allowlist) visits the landing page, **When** they sign in with Google, **Then** they see the waitlist/thank you page instead of the Tidal connection screen.
+2. **Given** a non-approved user is on the waitlist page, **When** they view the page content, **Then** it clearly communicates that AlgoJuke is in private beta and they will be notified when access is available.
+3. **Given** a non-approved user has seen the waitlist page, **When** they try to navigate directly to protected routes, **Then** they are redirected back to the waitlist page.
+
+---
+
+### User Story 3 - Landing Page Experience (Priority: P3)
+
+Any visitor (signed in or not) can view the landing page that explains what AlgoJuke is: an AI-powered music discovery service currently in private beta.
+
+**Why this priority**: The landing page is the first impression and explains the product value proposition. Important for marketing but not blocking core functionality.
+
+**Independent Test**: Can be tested by visiting the application URL without being signed in and verifying the landing page content displays correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor is not signed in, **When** they visit the application root URL, **Then** they see the landing page with service description.
+2. **Given** a visitor is viewing the landing page, **When** they read the content, **Then** they understand that AlgoJuke is an AI-powered music discovery service in private beta.
+3. **Given** a visitor is viewing the landing page, **When** they look for a way to sign in, **Then** they see a clear "Sign in with Google" button.
+
+---
+
+### User Story 4 - Approved User Without Tidal Connection (Priority: P4)
+
+An approved user signs in with Google but does not complete the Tidal connection (closes the window, navigates away, etc.). When they return, they are prompted to connect Tidal before accessing the main application.
+
+**Why this priority**: Handles an edge case where the user flow is interrupted. Lower priority because it's a recovery scenario, not the primary path.
+
+**Independent Test**: Can be tested by signing in with an allowlisted account, not completing Tidal connection, and verifying the Tidal connection prompt appears on subsequent visits.
+
+**Acceptance Scenarios**:
+
+1. **Given** an approved user has signed in with Google but not connected Tidal, **When** they try to access the main application, **Then** they are redirected to the Tidal connection screen.
+2. **Given** an approved user is on the Tidal connection screen, **When** they click "Connect Tidal," **Then** they are taken through the Tidal OAuth flow.
+
+---
+
+### Edge Cases
+
+- What happens when the Tidal OAuth flow fails or is cancelled? → User is returned to the Tidal connection screen with an error message and option to retry.
+- What happens when Tidal tokens expire? → User is prompted to reconnect their Tidal account when a token refresh fails.
+- What happens if the allowlist is updated while a user is logged in? → User's access status is checked on each protected route access; if removed from allowlist, they see the waitlist page.
+- What happens if a user's Google session expires? → User is redirected to sign in again with Google.
+- What happens if a non-approved user tries to directly access the Tidal connection endpoint? → They are blocked and shown the waitlist page.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a landing page accessible to all visitors explaining AlgoJuke as an AI-powered music discovery service in private beta.
+- **FR-002**: System MUST allow users to sign in using their Google account.
+- **FR-003**: System MUST maintain an allowlist of approved Google email addresses.
+- **FR-004**: System MUST check authenticated users against the allowlist to determine access level.
+- **FR-005**: Approved users MUST be prompted to connect their Tidal account after Google sign-in.
+- **FR-006**: System MUST implement Tidal OAuth 2.1 authorization code flow with PKCE for account connection, requesting scopes: `collection.read`, `playlists.read`, `playlists.write`, `recommendations.read`, `search.read`, `user.read`.
+- **FR-007**: System MUST store Tidal access tokens and refresh tokens in user-specific private metadata.
+- **FR-008**: System MUST handle Tidal token refresh when access tokens expire.
+- **FR-009**: Non-approved users MUST see a waitlist page thanking them for their interest and informing them of private beta status.
+- **FR-010**: Non-approved users MUST NOT be able to access the Tidal connection flow or main application features.
+- **FR-011**: Users who have completed both Google sign-in and Tidal connection MUST have full access to the main application.
+- **FR-012**: Users MUST remain signed in across browser sessions (standard session persistence).
+- **FR-013**: System MUST redirect unauthenticated users attempting to access protected routes to the landing page.
+- **FR-014**: System MUST redirect approved users without Tidal connection to the Tidal connection screen.
+- **FR-015**: The initial allowlist MUST include "anton.tcholakov@gmail.com" as the only approved email.
+- **FR-016**: Users MUST be able to sign out from their Google session; Tidal connection persists after sign-out.
+
+### Out of Scope
+
+- Tidal account disconnect/reconnect functionality (deferred to future social connections management feature)
+- Admin UI for managing the allowlist
+
+### Key Entities
+
+- **User**: Represents an authenticated user with Google identity, approval status (derived from allowlist), and optional Tidal connection status.
+- **Tidal Connection**: Represents the link between a user and their Tidal account, including access token, refresh token, and token expiration.
+- **Allowlist**: A configurable list of Google email addresses permitted to access the full application during private beta.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Approved users can complete the full sign-in and Tidal connection flow in under 60 seconds (excluding time spent on external auth screens).
+- **SC-002**: 100% of non-approved users are prevented from accessing protected application features.
+- **SC-003**: Returning users (already signed in with Tidal connected) can access the main application within 3 seconds of page load.
+- **SC-004**: Tidal token refresh succeeds automatically without user intervention at least 99% of the time during active sessions.
+- **SC-005**: Landing page headline and subheadline clearly communicate the service purpose (AI-powered music discovery, private beta). This is a UX content goal verified via acceptance testing, not a timed metric.
+- **SC-006**: Users experience zero data loss if they interrupt the Tidal connection flow and return later.
+
+## Clarifications
+
+### Session 2026-01-03
+
+- Q: What Tidal OAuth scopes are required? → A: `collection.read`, `playlists.read`, `playlists.write`, `recommendations.read`, `search.read`, `user.read`
+- Q: What sign-out capability is needed? → A: Sign-out from Google only; Tidal connection persists. Tidal disconnect is out of scope (future feature).
+
+## Assumptions
+
+- Users have a valid Google account to sign in with.
+- Users have a valid Tidal account to connect (subscription status is not validated at this stage).
+- The Tidal Developer Platform OAuth endpoints are available and functioning.
+- Clerk's private metadata storage is sufficient for storing Tidal OAuth tokens.
+- The allowlist is managed via code/configuration (no admin UI required for initial release).
+- Standard web browser with cookies enabled is used for authentication.

--- a/specs/016-clerk-tidal-auth/tasks.md
+++ b/specs/016-clerk-tidal-auth/tasks.md
@@ -1,0 +1,282 @@
+# Tasks: Clerk Authentication with Tidal Account Connection
+
+**Input**: Design documents from `/specs/016-clerk-tidal-auth/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Tests are included per Constitution (Test-First Development principle).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Web app**: `backend/src/`, `frontend/src/`
+- **Backend tests**: `backend/tests/contract/`, `backend/tests/integration/`
+- **Frontend tests**: `frontend/tests/components/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Install dependencies and configure environment
+
+- [x] T001 [P] Install Clerk backend dependencies (`@clerk/express`, `@clerk/backend`) in backend/package.json
+- [x] T002 [P] Install Clerk frontend dependencies (`@clerk/clerk-react`) in frontend/package.json
+- [x] T003 [P] Install Tidal SDK (`@tidal-music/auth`) in frontend/package.json
+- [x] T004 [P] Add Clerk environment variables to backend/.env.example (CLERK_PUBLISHABLE_KEY, CLERK_SECRET_KEY)
+- [x] T005 [P] Add Clerk environment variables to frontend/.env.example (VITE_CLERK_PUBLISHABLE_KEY)
+- [x] T006 [P] Add Tidal environment variables to frontend/.env.example (VITE_TIDAL_CLIENT_ID, VITE_TIDAL_REDIRECT_URI)
+- [x] T007 Configure Vite for HTTPS in frontend/vite.config.ts (required for Tidal OAuth)
+- [x] T008 Add TypeScript types for Clerk request context in backend/src/types/globals.d.ts
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T009 Create allowlist configuration in backend/src/config/allowlist.ts with isApprovedUser() function
+- [x] T010 Copy Zod schemas from contracts/schemas.ts to backend/src/schemas/auth.ts
+- [x] T011 Create Clerk middleware setup in backend/src/middleware/clerkAuth.ts with clerkMiddleware()
+- [x] T012 Create requireApproved middleware in backend/src/middleware/clerkAuth.ts (checks allowlist)
+- [x] T013 Add Clerk middleware to Express app in backend/src/server.ts
+- [x] T014 Create tidalAuthService in backend/src/services/tidalAuthService.ts (getTidalTokens, storeTidalTokens, hasTidalConnection)
+- [x] T015 Create auth routes file in backend/src/routes/auth.ts with Express Router
+- [x] T016 Register auth routes in backend/src/server.ts under /api/auth
+- [x] T017 Wrap React app with ClerkProvider in frontend/src/main.tsx
+- [x] T018 Create useTidalAuth hook in frontend/src/hooks/useTidalAuth.ts (manages Tidal SDK state)
+- [x] T019 Create ProtectedRoute component in frontend/src/components/auth/ProtectedRoute.tsx
+- [x] T020 Create AuthLayout component in frontend/src/components/layout/AuthLayout.tsx
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Approved User Signs In and Connects Tidal (Priority: P1)
+
+**Goal**: Enable approved users to sign in with Google and connect their Tidal account
+
+**Independent Test**: Sign in with anton.tcholakov@gmail.com, complete Tidal connection, verify access to main app
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T021 [P] [US1] Contract test for GET /api/auth/status endpoint in backend/tests/contract/auth/authStatus.test.ts
+- [x] T022 [P] [US1] Contract test for POST /api/auth/tidal/tokens endpoint in backend/tests/contract/auth/tidalTokens.test.ts
+- [x] T023 [P] [US1] Contract test for GET /api/auth/tidal/tokens endpoint in backend/tests/contract/auth/tidalTokenStatus.test.ts
+- [x] T024 [P] [US1] Integration test for approved user auth flow in backend/tests/integration/auth/approvedUserFlow.test.ts
+
+### Implementation for User Story 1
+
+- [x] T025 [US1] Implement GET /api/auth/status endpoint in backend/src/routes/auth.ts
+- [x] T026 [US1] Implement POST /api/auth/tidal/tokens endpoint in backend/src/routes/auth.ts (requires approved user)
+- [x] T027 [US1] Implement GET /api/auth/tidal/tokens endpoint in backend/src/routes/auth.ts
+- [x] T028 [P] [US1] Create TidalConnectPage in frontend/src/pages/TidalConnectPage.tsx
+- [x] T029 [P] [US1] Create TidalConnectButton component in frontend/src/components/auth/TidalConnectButton.tsx
+- [x] T030 [US1] Create CallbackPage for Tidal OAuth in frontend/src/pages/CallbackPage.tsx
+- [x] T031 [US1] Add Tidal connection routes to frontend/src/App.tsx (/connect-tidal, /auth/tidal/callback)
+- [x] T032 [US1] Implement redirect to main app after successful Tidal connection in CallbackPage
+- [x] T033 [US1] Update ProtectedRoute to redirect approved users without Tidal to /connect-tidal
+
+**Checkpoint**: Approved users can complete full sign-in and Tidal connection flow
+
+---
+
+## Phase 4: User Story 2 - Non-Approved User Experience (Priority: P2)
+
+**Goal**: Show waitlist page to users not on the allowlist
+
+**Independent Test**: Sign in with non-allowlisted Google account, verify waitlist page appears
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T034 [P] [US2] Contract test for 403 response on non-approved POST /api/auth/tidal/tokens in backend/tests/contract/auth/tidalTokensUnauthorized.test.ts
+- [x] T035 [P] [US2] Component test for WaitlistPage in frontend/tests/components/auth/WaitlistPage.test.tsx
+
+### Implementation for User Story 2
+
+- [x] T036 [P] [US2] Create WaitlistPage in frontend/src/pages/WaitlistPage.tsx
+- [x] T037 [US2] Update ProtectedRoute to redirect non-approved users to /waitlist
+- [x] T038 [US2] Add waitlist route to frontend/src/App.tsx (/waitlist)
+- [x] T039 [US2] Ensure direct URL access to protected routes redirects non-approved users to waitlist
+
+**Checkpoint**: Non-approved users are gracefully handled with waitlist page
+
+---
+
+## Phase 5: User Story 3 - Landing Page Experience (Priority: P3)
+
+**Goal**: Public landing page explaining AlgoJuke service
+
+**Independent Test**: Visit root URL without signing in, verify landing page displays
+
+### Tests for User Story 3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T040 [P] [US3] Component test for LandingPage in frontend/tests/components/auth/LandingPage.test.tsx
+
+### Implementation for User Story 3
+
+- [x] T041 [US3] Create LandingPage in frontend/src/pages/LandingPage.tsx with service description
+- [x] T042 [US3] Add Clerk SignInButton to LandingPage (Sign in with Google)
+- [x] T043 [US3] Add landing page route to frontend/src/App.tsx (root /)
+- [x] T044 [US3] Style LandingPage with AlgoJuke branding and private beta messaging
+
+**Checkpoint**: Landing page provides clear value proposition and sign-in option
+
+---
+
+## Phase 6: User Story 4 - Approved User Without Tidal Connection (Priority: P4)
+
+**Goal**: Handle interrupted Tidal connection flow gracefully
+
+**Independent Test**: Sign in as approved user, don't complete Tidal, revisit - verify redirect to connect page
+
+### Tests for User Story 4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T045 [P] [US4] Integration test for incomplete Tidal flow in backend/tests/integration/auth/incompleteTidalFlow.test.ts
+
+### Implementation for User Story 4
+
+- [x] T046 [US4] Add error handling to TidalConnectPage for cancelled/failed OAuth
+- [x] T047 [US4] Persist auth state check in useTidalAuth hook for returning users
+- [x] T048 [US4] Add retry button to TidalConnectPage for failed connections
+
+**Checkpoint**: Interrupted flows are handled with clear recovery path
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T049 [P] Contract test for POST /api/auth/tidal/refresh endpoint in backend/tests/contract/auth/tidalRefresh.test.ts
+- [x] T050 Implement POST /api/auth/tidal/refresh endpoint in backend/src/routes/auth.ts
+- [x] T051 [P] Add sign-out button (UserButton from Clerk) to authenticated pages
+- [x] T052 [P] Add loading states to auth components (TidalConnectPage, CallbackPage)
+- [x] T053 [P] Add error boundary for auth-related errors in frontend
+- [x] T054 Run quickstart.md validation to verify full flow works
+- [x] T055 Update backend/README.md with auth setup instructions
+- [x] T056 Update frontend/README.md with auth setup instructions
+- [x] T057 [FR-012] Integration test for session persistence in backend/tests/integration/auth/sessionPersistence.test.ts (verify Clerk session survives browser refresh)
+- [x] T058 [SC-004] Add structured logging for Tidal token refresh operations in backend/src/services/tidalAuthService.ts (success/failure with duration)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-6)**: All depend on Foundational phase completion
+  - User stories can then proceed in parallel (if staffed)
+  - Or sequentially in priority order (P1 → P2 → P3 → P4)
+- **Polish (Phase 7)**: Depends on at least User Story 1 being complete
+
+### User Story Dependencies
+
+| Story | Can Start After | Dependencies on Other Stories |
+|-------|-----------------|-------------------------------|
+| US1 (P1) | Foundational | None |
+| US2 (P2) | Foundational | None (but uses ProtectedRoute from US1) |
+| US3 (P3) | Foundational | None |
+| US4 (P4) | Foundational | Builds on US1 TidalConnectPage |
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Backend endpoints before frontend that calls them
+- Core components before integration
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel (T001-T008)
+- Contract tests within a story marked [P] can run in parallel
+- Frontend pages marked [P] can be created in parallel
+- Different user stories can be worked on in parallel after Foundational phase
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```bash
+# All these can run simultaneously:
+T001: Install Clerk backend dependencies in backend/package.json
+T002: Install Clerk frontend dependencies in frontend/package.json
+T003: Install Tidal SDK in frontend/package.json
+T004: Add Clerk env vars to backend/.env.example
+T005: Add Clerk env vars to frontend/.env.example
+T006: Add Tidal env vars to frontend/.env.example
+```
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# All tests can be written in parallel:
+T021: Contract test for GET /api/auth/status
+T022: Contract test for POST /api/auth/tidal/tokens
+T023: Contract test for GET /api/auth/tidal/tokens
+T024: Integration test for approved user flow
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (8 tasks)
+2. Complete Phase 2: Foundational (12 tasks)
+3. Complete Phase 3: User Story 1 (13 tasks)
+4. **STOP and VALIDATE**: Test with anton.tcholakov@gmail.com
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → **MVP Ready!**
+3. Add User Story 2 → Non-approved users handled
+4. Add User Story 3 → Public landing page
+5. Add User Story 4 → Edge case recovery
+6. Polish → Full feature complete
+
+### Task Summary
+
+| Phase | Tasks | Cumulative |
+|-------|-------|------------|
+| Setup | 8 | 8 |
+| Foundational | 12 | 20 |
+| User Story 1 | 13 | 33 |
+| User Story 2 | 6 | 39 |
+| User Story 3 | 5 | 44 |
+| User Story 4 | 4 | 48 |
+| Polish | 10 | 58 |
+
+**Total Tasks**: 58
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- HTTPS required for Tidal OAuth (ensure vite.config.ts is configured)


### PR DESCRIPTION
## Summary

This PR implements the complete authentication infrastructure for AlgoJuke's private beta, using Clerk for identity management and the Tidal SDK for music service OAuth.

### Key Features

- **Private Beta Access Control**: Email allowlist gates access to approved users only
- **Two-Step Authentication**: Clerk (identity) + Tidal (music service) OAuth flow
- **Token Management**: Secure storage via Clerk private metadata with automatic refresh
- **Protected Routes**: Multi-level guards (authenticated → approved → Tidal connected)

### Backend Changes

| Component | Description |
|-----------|-------------|
| `middleware/clerkAuth.ts` | JWT validation middleware with session augmentation |
| `config/allowlist.ts` | Hardcoded email allowlist for private beta |
| `routes/auth.ts` | Auth endpoints: status, token storage, token status, refresh |
| `services/tidalAuthService.ts` | Tidal token CRUD via Clerk private metadata |
| `schemas/auth.ts` | Zod schemas for request/response validation |

### Frontend Changes

| Component | Description |
|-----------|-------------|
| `pages/LandingPage.tsx` | Google OAuth sign-in via Clerk |
| `pages/WaitlistPage.tsx` | Holding page for non-approved users |
| `pages/TidalConnectPage.tsx` | Tidal OAuth initiation with feature list |
| `pages/CallbackPage.tsx` | OAuth callback handling (success/error/cancelled) |
| `components/auth/ProtectedRoute.tsx` | Route guard with redirect logic |
| `hooks/useTidalAuth.ts` | Tidal SDK wrapper managing OAuth and token sync |

### Auth Flow Diagram

```
┌─────────────┐    ┌─────────────┐    ┌──────────────┐    ┌─────────────┐
│   Landing   │───►│  Waitlist   │    │ TidalConnect │───►│  Callback   │
│   (Clerk)   │    │(not approved)│    │   (OAuth)    │    │  (finalize) │
└─────────────┘    └─────────────┘    └──────────────┘    └─────────────┘
       │                                      ▲                   │
       │ approved                             │                   │ success
       └──────────────────────────────────────┘                   │
                                                                  ▼
                                                          ┌─────────────┐
                                                          │  /discover  │
                                                          │ (protected) │
                                                          └─────────────┘
```

### Test Coverage

- **Backend**: 59 tests (contract + integration)
  - Auth status endpoint contract tests
  - Token storage/retrieval contract tests
  - Approved user flow integration tests
  - Session persistence integration tests
  - Incomplete flow edge case tests

- **Frontend**: 37 tests (component + hook)
  - ProtectedRoute redirect logic (8 tests)
  - TidalConnectPage interactions (9 tests)
  - CallbackPage state handling (8 tests)
  - useTidalAuth hook behavior (12 tests)

### Environment Variables

**Backend** (`.env`):
- `CLERK_PUBLISHABLE_KEY` - Clerk frontend key
- `CLERK_SECRET_KEY` - Clerk backend key

**Frontend** (`.env`):
- `VITE_CLERK_PUBLISHABLE_KEY` - Clerk frontend key
- `VITE_TIDAL_CLIENT_ID` - Tidal OAuth client ID
- `VITE_TIDAL_REDIRECT_URI` - OAuth callback URL

### Review Notes

1. The email allowlist is hardcoded in `backend/src/config/allowlist.ts` for private beta simplicity
2. Tidal SDK manages token refresh internally; frontend syncs refreshed tokens to backend
3. Return URL is preserved in sessionStorage across OAuth redirects
4. OAuth cancellation shows a friendly message distinct from error states

## Test plan

- [ ] Verify type checks pass: `npm run type-check` in both backend and frontend
- [ ] Run backend auth tests: `npm test -- tests/contract/auth tests/integration/auth`
- [ ] Run frontend auth tests: `npm test -- tests/components/auth tests/hooks`
- [ ] Manual test: Sign in with approved email → connect Tidal → access /discover
- [ ] Manual test: Sign in with non-approved email → redirected to waitlist
- [ ] Manual test: Cancel Tidal OAuth → see cancellation message with retry option

🤖 Generated with [Claude Code](https://claude.com/claude-code)